### PR TITLE
Fix command for workaround for disabling Kubernetes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -60,7 +60,7 @@ https://github.com/docker/compose
 
 ```bash
 kubectl config use-context rancher-desktop
-kubectl delete node lima rancher-desktop
+kubectl delete node lima-rancher-desktop
 ```
 
 <!-- #726 -->


### PR DESCRIPTION
➜  ~ kubectl config use-context rancher-desktop
Switched to context "rancher-desktop".
➜  ~ kubectl delete node lima rancher-desktop
Error from server (NotFound): nodes "lima" not found
Error from server (NotFound): nodes "rancher-desktop" not found
➜  ~ kubectl delete node lima-rancher-desktop
node "lima-rancher-desktop" deleted