### PR TITLE
Add docs to get around kvm permissions issue

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,7 +118,7 @@ Rancher Desktop requires the following on Linux:
 
 - A distribution that can install .deb or .rpm packages, or AppImages.
 - A persistent internet connection.
-- An x86_64 processor with either AMD-V or VT-X.
+- An x86_64 processor with either AMD-V or VT-x.
 - Read-write access on `/dev/kvm`. See below for details.
 
 It is also recommended to have:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,6 +118,8 @@ Rancher Desktop requires the following on Linux:
 
 - A distribution that can install .deb or .rpm packages, or AppImages.
 - A persistent internet connection.
+- An x86_64 processor with either AMD-V or VT-X.
+- Read-write access on `/dev/kvm`. See below for details.
 
 It is also recommended to have:
 
@@ -126,18 +128,10 @@ It is also recommended to have:
 
 Additional resources may be required depending on the workloads you plan to run.
 
-### Installation via .deb Package
 
-Add the Rancher Desktop repository and install Rancher Desktop with:
+### Ensuring You Have Access to `/dev/kvm`
 
-```
-curl https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/Release.key | sudo apt-key add -
-sudo add-apt-repository 'deb https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/ ./'
-sudo apt update
-sudo apt install rancher-desktop
-```
-
-On some distributions (Ubuntu 18.04 is one example) the user has insufficient
+On some distributions (Ubuntu 18.04 for example) the user has insufficient
 privileges to use `/dev/kvm`, which is required for Rancher Desktop.
 To check whether you have the required privileges, do:
 
@@ -153,6 +147,19 @@ adduser "$USER" kvm
 ```
 
 Then reboot in order to make these changes take effect.
+
+
+### Installation via .deb Package
+
+Add the Rancher Desktop repository and install Rancher Desktop with:
+
+```
+curl https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/Release.key | sudo apt-key add -
+sudo add-apt-repository 'deb https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/ ./'
+sudo apt update
+sudo apt install rancher-desktop
+```
+
 
 ### Uninstalling .deb Package
 
@@ -175,6 +182,7 @@ uid           [ unknown] isv:Rancher:stable OBS Project <isv:Rancher:stable@buil
 ```
 
 then my `keyid` is `236E B3BE 8504 1EAE C40B  2641 2431 4E44 EE21 3962`.
+
 
 ### Installing via .rpm Package
 
@@ -199,6 +207,7 @@ sudo zypper remove --clean-deps rancher-desktop
 sudo zypper removerepo isv_Rancher_stable
 ```
 
+
 ### Installing via AppImage
 
 You may download the AppImage [here].
@@ -210,6 +219,7 @@ For better integration with your desktop, you may use [AppImageLauncher].
 https://download.opensuse.org/repositories/isv:/Rancher:/stable/AppImage/rancher-desktop-latest-x86_64.AppImage
 [AppImageLauncher]:
 https://github.com/TheAssassin/AppImageLauncher
+
 
 ### Uninstalling AppImage
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,6 +137,23 @@ sudo apt update
 sudo apt install rancher-desktop
 ```
 
+On some distributions (Ubuntu 18.04 is one example) the user has insufficient
+privileges to use `/dev/kvm`, which is required for Rancher Desktop.
+To check whether you have the required privileges, do:
+
+```
+[ -r /dev/kvm ] && [ -w /dev/kvm ] || echo 'insufficient privileges'
+```
+
+If it outputs `insufficient privileges`, you need to add your user to the
+`kvm` group. You can do this with:
+
+```
+adduser "$USER" kvm
+```
+
+Then reboot in order to make these changes take effect.
+
 ### Uninstalling .deb Package
 
 You can remove the package, repository, and key with:


### PR DESCRIPTION
[This issue][issue] is caused by the user not having sufficient permissions to access `/dev/kvm`. On other tested distributions there is no problem because the user has the needed permissions on `/dev/kvm` via either file ACLs or SELinux policies. The only solution I am aware of is to add another (simple) step to documentation, which is what this PR does.

[issue]: https://github.com/rancher-sandbox/rancher-desktop/issues/1344