### PR TITLE
Document Windows port exposing workaround

### DIFF
--- a/docs/tutorials/working-with-containers.md
+++ b/docs/tutorials/working-with-containers.md
@@ -108,9 +108,9 @@ docker run -d -p 8000:80 nginx
   </TabItem>
 </Tabs>
 
-You can then access the container via the browser here: [http://localhost:8080/](http://localhost:8080/).  The port will be accessible on all network interfaces of the host machine.
+You can then access the container via the browser here: [http://localhost:8080/](http://localhost:8080/).
 
-*Note: Exposed ports on Windows are currently only accessible through the `localhost` network interface (see issue [#1180](https://github.com/rancher-sandbox/rancher-desktop/issues/1180)).  As a workaround, you can [configure a `portproxy` on the windows host](https://github.com/rancher-sandbox/rancher-desktop/issues/1180#issuecomment-1005514200) to expose the port to additional network interfaces.*
+*Note: By default the exposed ports are accessible on all network interfaces on macOS and Linux. However, on Windows, the exposed ports are currently only accessible through the localhost network interface (see issue [#1180](https://github.com/rancher-sandbox/rancher-desktop/issues/1180)).  As a workaround, you can [configure a `portproxy` on the windows host](https://github.com/rancher-sandbox/rancher-desktop/issues/1180#issuecomment-1005514200) to expose the port to additional network interfaces.*
 
 ```
 netsh interface portproxy add v4tov4 listenport=8080 listenaddress=0.0.0.0 connectport=8080 connectaddress=localhost

--- a/docs/tutorials/working-with-containers.md
+++ b/docs/tutorials/working-with-containers.md
@@ -108,23 +108,13 @@ docker run -d -p 8000:80 nginx
   </TabItem>
 </Tabs>
 
-You can then access the container via the browser here: [http://localhost:8080/](http://localhost:8080/).
+You can then access the container via the browser here: [http://localhost:8080/](http://localhost:8080/).  The port will be accessible on all network interfaces of the host machine.
 
-<Tabs groupId="container-runtime">
-  <TabItem value="nerdctl" default>
-
-```
-nerdctl build -t demo:latest /code/demos/rd/anvil-app
-```
-
-  </TabItem>
-  <TabItem value="docker" default>
+*Note: Exposed ports on Windows are currently only accessible through the `localhost` network interface (see issue [#1180](https://github.com/rancher-sandbox/rancher-desktop/issues/1180)).  As a workaround, you can [configure a `portproxy` on the windows host](https://github.com/rancher-sandbox/rancher-desktop/issues/1180#issuecomment-1005514200) to expose the port to additional network interfaces.*
 
 ```
-docker build -t demo:latest /code/demos/rd/anvil-app
+netsh interface portproxy add v4tov4 listenport=8080 listenaddress=0.0.0.0 connectport=8080 connectaddress=localhost
 ```
-  </TabItem>
-</Tabs>
 
 ## Targeting a Kubernetes Namespace
 


### PR DESCRIPTION
Add some additional documentation about exposing ports to all network interfaces on windows.
Fixes: #76 

Also removed some out of place code samples in the "Exposing a Port" section that were building a container.