### PR TITLE
Changed sidebar behavior

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,6 +24,8 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          sidebarCollapsed: true,
+          sidebarCollapsible: true,
           // Please change this to your repo.
           editUrl: 'https://github.com/rancher-sandbox/docs.rancherdesktop.io/edit/main',
           versions: {
@@ -65,6 +67,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      docs: {
+        sidebar: {
+          autoCollapseCategories: true,
+        },
+      },
       navbar: {
         logo: {
           alt: 'Rancher Desktop Logo',

--- a/sidebars.js
+++ b/sidebars.js
@@ -57,7 +57,6 @@ const sidebars = {
         "tutorials/working-with-images",
         "tutorials/working-with-containers",
       ],
-      collapsed: true,
     },
     {
       type: 'category',
@@ -74,7 +73,6 @@ const sidebars = {
         "how-to-guides/provisioning-scripts",
         "how-to-guides/running-air-gapped"
       ],
-      collapsed: true,
     },
     {
       type: 'category',
@@ -84,7 +82,6 @@ const sidebars = {
         "references/rdctl-command-reference",
         "references/bundled-utilities"
       ],
-      collapsed: true,
     },
     "faq",
     "troubleshooting-tips"


### PR DESCRIPTION
The sidebar starts now fully collapsed except for `Getting started` category, and only one category can be expanded while the others are automatically collapsed.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>