### PR TITLE
Simplify explanation of Allowed Images patterns

### DIFF
--- a/docs/ui/preferences/container-engine.md
+++ b/docs/ui/preferences/container-engine.md
@@ -35,11 +35,11 @@ When switching to a different container runtime:
 
 ## Allowed Images
 
-The `Allowed Images` tab provides options to let you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image URL patterns to allow accessing images only from specific registries and/or repositories.
+The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.
 
-Check the **Enable** checkbox to enable Rancher Desktop to apply the specified patterns while pulling images, which means only the image URLs that match atleast one of the specified patterns will be allowed.
+Check the **Enable** checkbox to enable Rancher Desktop to apply the specified patterns while pulling or pushing images, which means only images whose names match at least one of the specified patterns will be allowed.
 
-You can use the **+** and **-** buttons to add/remove image URL patterns. 
+You can use the **+** and **-** buttons to add/remove image name patterns. 
 
 <Tabs groupId="os">
 <TabItem value="Windows">
@@ -61,23 +61,25 @@ You can use the **+** and **-** buttons to add/remove image URL patterns.
 
 ### How to specify Allowed Image patterns
 
-You can specify Allowed Image patterns using the format `[registryServerUrl/][:port/][organization/]repository[:tag]`. Rancher Desktop supports using regular expressions in any part of an Allowed Image pattern string.
+You can specify Allowed Image patterns using the format `[registry/][:port/][organization/]repository[:tag]`.
 
-> If not specified in an Allowed Image pattern string,
-> * `registryServerUrl` defaults to DockerHub registry (`registry-1.docker.io`).
-> * `port` defaults to 433, but is optional because the HTTP "Host" header may not include it. 
-> * `organization` for DockerHub registry defaults to `library`, and for non-DockerHub registries defaults to no organization.
-> * `tag` defaults to anything (not including a `/`) and NOT just to `latest`.
+> If not specified in an Allowed Image pattern,
+> * `registry` defaults to Docker Hub (`docker.io`).
+> * `port` defaults to 433. 
+> * `organization` for Docker Hub defaults to `library`, and does not apply to other registries.
+> * `tag` defaults to anything and **not** just to `latest`.
+
+**Note:** Filtering by `tag` does not actually work; the corresponding digests (`repository@digest`) will have to be added to the allow list as well, making this impractical. Please file a Github issue if you have a use-case that requires filtering based on tags!
 
 ### Examples
 
-| Pattern | Equivalent Fully Formed RegEx | Meaning |
-| ------------- | ---------------- | ---------------- |
-| busybox | ` ~*^registry-1.docker.io(:443)?/library/busybox/manifests/[^/]+$ 0 ` | Allow all tags of the image `busybox` in the default organization `library` and from the default registry `registry-1.docker.io`|
-| suse/ | `~*^registry-1.docker.io(:443)?/suse/[^/]+/manifests/[^/]+$ 0` | Allow any tag of any image in the specified organization `suse` and from the default regsitry `registry-1.docker.io` <br/> **Note:** A trailing slash on the repository means a single segment follows, e.g. "suse/nginx", but not "suse/foo/bar". |
-| rancher/mirrored-\[^/\]+ | `~*^registry-1.docker.io(:443)?/rancher/mirrored-[^/]+/manifests/[^/]+$ 0` | Allow any tag of any image whose name starts with `mirrored`, and in the specified organization `rancher` and from the default registry `registry-1.docker.io` |
-| registry.suse.com/image | `~*^registry.suse.com(:443)?/image/manifests/[^/]+$ 0` | Allow any tag of the image `image` from the specified registry `registry.suse.com` <br/> **Note:** Non-DockerHub registries do not mandate to have organizations, so can have images at the top level (no default organization `library` is inserted). |
-| registry.home:5000 | `~*^registry.home:5000/.+/manifests/[^/]+$ 0` | Allow any tag of any image in any organization (or no organization) and from the specified registry `registry.home:5000` |
+| Pattern                   | Meaning                                                                                                                                                                                                             |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `busybox`                 | Allow the `busybox` repository in the `library` organization of the `docker.io` registry.                                                                                                       |
+| `suse/`                   | Allow any image in the `suse` organization of the `docker.io` registry. <br/> **Note:** A trailing slash at the end of the repository means a single segment follows, e.g. `suse/nginx`, but not `suse/cap/uaa`.    |
+| `suse//`                  | Allow any image in the `suse` organization of the `docker.io` registry. <br/> **Note:** A trailing double slash at the end of the repository means one or more segments follow, e.g. `suse/cap/uaa`.                |
+| `registry.internal:5000`  | Allow any image from the `registry.internal:5000` registry.                                                                                                                                                         |
+| `registry.suse.com/nginx` | Allow the image `nginx` from the `registry.suse.com` registry. <br/> **Note:** Non-DockerHub registries do not have the concept of organizations at the top level, so no default `library` organization is implied. |
 
 
 [container runtime]:


### PR DESCRIPTION
We will likely simplify the patterns from regular expressions to simply allow '*' wildcards, so anything referencing regular expressions has been removed.

Also added a note that filtering by tag doesn't actually work.
