### PR TITLE
Added CN translations for latest sidebar

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest.json
@@ -18,5 +18,13 @@
   "sidebar.tutorialSidebar.category.References": {
     "message": "参考",
     "description": "The label for category References in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.User Interface": {
+    "message": "用户界面",
+    "description": "The label for category User Interface in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Preferences": {
+    "message": "偏好设置",
+    "description": "The label for category Preferences in sidebar tutorialSidebar"
   }
 }


### PR DESCRIPTION
The translated sidebar for the `latest` version was missing `User Interface` and `Preferences`.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>