### PR TITLE
Add shadows to docs images

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -26,3 +26,10 @@
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+.img_ev3q {
+  box-shadow: 10px 10px 25px rgb(100, 100, 100);
+  -moz-box-shadow: 10px 10px 25px rgb(100, 100, 100);
+  -webkit-box-shadow: 10px 10px 25px rgb(100, 100, 100);
+  -khtml-box-shadow: 10px 10px 25px rgb(100, 100, 100);
+}


### PR DESCRIPTION
Added shadows to images and to avoid setting a shadow to the logo, the style is based on the class ID which is set by Docusaurus when building the docs. The class ID is constant across the builds.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>