### PR TITLE
Updated the capitalization to "Port Forwarding" and "Container Engine"

### DIFF
--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Port forwarding
-title: Port forwarding
+sidebar_label: Port Forwarding
+title: Port Forwarding
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/ui/preferences/container-engine.md
+++ b/docs/ui/preferences/container-engine.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Container engine
-title: Container engine
+sidebar_label: Container Engine
+title: Container Engine
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-1.7/ui/port-forwarding.md
+++ b/versioned_docs/version-1.7/ui/port-forwarding.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Port forwarding
-title: Port forwarding
+sidebar_label: Port Forwarding
+title: Port Forwarding
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-1.7/ui/preferences/container-engine.md
+++ b/versioned_docs/version-1.7/ui/preferences/container-engine.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Container engine
-title: Container engine
+sidebar_label: Container Engine
+title: Container Engine
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-latest/ui/port-forwarding.md
+++ b/versioned_docs/version-latest/ui/port-forwarding.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Port forwarding
-title: Port forwarding
+sidebar_label: Port Forwarding
+title: Port Forwarding
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-latest/ui/preferences/container-engine.md
+++ b/versioned_docs/version-latest/ui/preferences/container-engine.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Container engine
-title: Container engine
+sidebar_label: Container Engine
+title: Container Engine
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
In the sidebar, updated the capitalization from "Port forwarding" to "Port Forwarding" and "Container engine" to "Container Engine" to match standard page names. This PR addresses #133 .

Signed-off-by: Sunil Singh <sunil.singh@suse.com>