### PR TITLE
Removed defaultValue from Tabs

### DIFF
--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -13,7 +13,7 @@ On macOS and Linux, you can use lima override.yaml to write provisioning scripts
 
 - Create `override.yaml` file at below path
 
-<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<Tabs groupId="os">
   <TabItem value="macOS">
 
 ```

--- a/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
@@ -13,7 +13,7 @@ On macOS and Linux, you can use lima override.yaml to write provisioning scripts
 
 - Create `override.yaml` file at below path
 
-<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<Tabs groupId="os">
   <TabItem value="macOS">
 
 ```

--- a/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
@@ -13,7 +13,7 @@ On macOS and Linux, you can use lima override.yaml to write provisioning scripts
 
 - Create `override.yaml` file at below path
 
-<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<Tabs groupId="os">
   <TabItem value="macOS">
 
 ```


### PR DESCRIPTION
The field `defaultValue` in the Provisioning page tabs causes a page crash on Windows machines as the Tabs only have MacOS and Linux.

The option was removed and the page is displayed correctly.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>