### PR TITLE
Updating Running When Offline Documentation

### DIFF
--- a/docs/how-to-guides/running-air-gapped.md
+++ b/docs/how-to-guides/running-air-gapped.md
@@ -9,7 +9,6 @@ import TabsConstants from '@site/core/TabsConstants';
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 
-
 ### A Note for Windows users
 
 This document uses Powershell syntax for environment variables. If you're using the Command shell
@@ -25,7 +24,7 @@ There are two areas where Rancher Desktop assumes network availability and will 
 
 ### Existing Deployments
 
-If Rancher Desktop has been installed on a machine initially with networked access, it can 
+If Rancher Desktop has been installed on a machine initially with networked access, it can
 be run subsequently on that machine after network connectivity has been turned off. The main
 difference in core functionality is that the list of versions of Kubernetes available in drop-down menus
 is limited to those versions that have actually been downloaded and stored in the cache.
@@ -43,7 +42,7 @@ Suppose there are three versions of `k3s` in the `rancher-desktop` cache.
 
 - 1.19.16
 
-But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that 
+But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that
 the `~/.kuberlr/PLATFORM-ARCH/` directory (`$env:HOMEDRIVE%\$env:HOMEPATH/.kuberlr/windows-amd64` on Windows) will contain only two files:
 
 - kubectl1.24.3
@@ -71,7 +70,7 @@ There are two directories that need to be populated in order for Rancher Desktop
 To populate a source disk (which we refer to here as `%SOURCEDISK%`, although it is probably some kind of removable medium like a USB thumb drive), you need the following files:
 
 * `k3s-versions.json` -- this file is created by Rancher Desktop. It reads a raw JSON file from `https://update.k3s.io/v1-release/channels` and converts it into a different kind of JSON file. Currently there is no utility to do that conversion; the easiest way to get this file is to run Rancher Desktop on a connected system and save the `CACHE/k3s-versions.json` file (see below for where `CACHE` exists on different platforms).
-* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases, and you'll want to download `k3s-airgap-images-amd64.tar` or `k3s-airgap-images-arm64.tar` (for AMD/intel and M1 machines respectively) for the versions you plan on working with. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
+* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases. You'll want to download either the `k3s-airgap-images-amd64.tar` for AMD/Intel machines, `k3s-airgap-images-arm64.tar` for M1 machines, or the respective `*.tar.zst` compressed tarball if you are using `k3s` v1.26.1 and above. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
 
 ```
 cd .../CACHE

--- a/versioned_docs/version-1.6/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.6/how-to-guides/running-air-gapped.md
@@ -8,7 +8,6 @@ import TabItem from '@theme/TabItem';
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 
-
 ### A Note for Windows users
 
 This document uses Powershell syntax for environment variables. If you're using the Command shell
@@ -24,7 +23,7 @@ There are two areas where Rancher Desktop assumes network availability and will 
 
 ### Existing Deployments
 
-If Rancher Desktop has been installed on a machine initially with networked access, it can 
+If Rancher Desktop has been installed on a machine initially with networked access, it can
 be run subsequently on that machine after network connectivity has been turned off. The main
 difference in core functionality is that the list of versions of Kubernetes available in drop-down menus
 is limited to those versions that have actually been downloaded and stored in the cache.
@@ -42,7 +41,7 @@ Suppose there are three versions of `k3s` in the `rancher-desktop` cache.
 
 - 1.19.16
 
-But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that 
+But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that
 the `~/.kuberlr/PLATFORM-ARCH/` directory (`$env:HOMEDRIVE%\$env:HOMEPATH/.kuberlr/windows-amd64` on Windows) will contain only two files:
 
 - kubectl1.24.3
@@ -53,7 +52,7 @@ If we go offline and use the UI to switch to Kubernetes `1.19.16`, when `kubectl
 The problem is that `kubectl` is an alias for `kuberlr`, which will try to download `kubectl 1.19.16` and install it
 in the `.kuberlr` directory, but won't be able to access it.
 
-So in this case, it would be best to prepare a connected system for disconnecting by selecting each available version of 
+So in this case, it would be best to prepare a connected system for disconnecting by selecting each available version of
 Kubernetes currently in the cache, and running `kubectl --context rancher-desktop cluster-info` to ensure that an appropriate
 version of the `kubectl` client is installed.
 
@@ -70,7 +69,7 @@ There are two directories that need to be populated in order for Rancher Desktop
 To populate a source disk (which we refer to here as `%SOURCEDISK%`, although it is probably some kind of removable medium like a USB thumb drive), you need the following files:
 
 * `k3s-versions.json` -- this file is created by Rancher Desktop. It reads a raw JSON file from `https://update.k3s.io/v1-release/channels` and converts it into a different kind of JSON file. Currently there is no utility to do that conversion; the easiest way to get this file is to run Rancher Desktop on a connected system and save the `CACHE/k3s-versions.json` file (see below for where `CACHE` exists on different platforms).
-* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases, and you'll want to download `k3s-airgap-images-amd64.tar` or `k3s-airgap-images-arm64.tar` (for AMD/intel and M1 machines respectively) for the versions you plan on working with. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
+* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases. You'll want to download either the `k3s-airgap-images-amd64.tar` for AMD/Intel machines, `k3s-airgap-images-arm64.tar` for M1 machines, or the respective `*.tar.zst` compressed tarball if you are using `k3s` v1.26.1 and above. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
 
 ```
 cd .../CACHE
@@ -161,4 +160,4 @@ wget -O %SOURCEDISK/kubectl1.22.1.exe https://dl.k8s.io/v1.22.1/bin/windows/amd6
 
 ##### A Note on Versions
 
-Kubectl clients are guaranteed to work with servers that are running the same MAJOR version and differ in the MINOR version by at most 1. So for example, if your organization is working with Kubernetes versions v1.21.x, v1.22.x, and v1.23.x, for any patch-version of `x`, you would only need to install `kubectl1.22.x` in the `.kuberlr` directory. But if you copy a `v1.24.x` of Kubernetes into the `CACHE` directory, you'll need to ensure there's a compatible `kubectl` in the `.kuberlr` directory as well (any of `v1.23.x`, `v1.24.x`, or `v1.25.x` would suffice). 
+Kubectl clients are guaranteed to work with servers that are running the same MAJOR version and differ in the MINOR version by at most 1. So for example, if your organization is working with Kubernetes versions v1.21.x, v1.22.x, and v1.23.x, for any patch-version of `x`, you would only need to install `kubectl1.22.x` in the `.kuberlr` directory. But if you copy a `v1.24.x` of Kubernetes into the `CACHE` directory, you'll need to ensure there's a compatible `kubectl` in the `.kuberlr` directory as well (any of `v1.23.x`, `v1.24.x`, or `v1.25.x` would suffice).

--- a/versioned_docs/version-1.7/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.7/how-to-guides/running-air-gapped.md
@@ -9,7 +9,6 @@ import TabsConstants from '@site/core/TabsConstants';
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 
-
 ### A Note for Windows users
 
 This document uses Powershell syntax for environment variables. If you're using the Command shell
@@ -25,7 +24,7 @@ There are two areas where Rancher Desktop assumes network availability and will 
 
 ### Existing Deployments
 
-If Rancher Desktop has been installed on a machine initially with networked access, it can 
+If Rancher Desktop has been installed on a machine initially with networked access, it can
 be run subsequently on that machine after network connectivity has been turned off. The main
 difference in core functionality is that the list of versions of Kubernetes available in drop-down menus
 is limited to those versions that have actually been downloaded and stored in the cache.
@@ -43,7 +42,7 @@ Suppose there are three versions of `k3s` in the `rancher-desktop` cache.
 
 - 1.19.16
 
-But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that 
+But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that
 the `~/.kuberlr/PLATFORM-ARCH/` directory (`$env:HOMEDRIVE%\$env:HOMEPATH/.kuberlr/windows-amd64` on Windows) will contain only two files:
 
 - kubectl1.24.3
@@ -54,7 +53,7 @@ If we go offline and use the UI to switch to Kubernetes `1.19.16`, when `kubectl
 The problem is that `kubectl` is an alias for `kuberlr`, which will try to download `kubectl 1.19.16` and install it
 in the `.kuberlr` directory, but won't be able to access it.
 
-So in this case, it would be best to prepare a connected system for disconnecting by selecting each available version of 
+So in this case, it would be best to prepare a connected system for disconnecting by selecting each available version of
 Kubernetes currently in the cache, and running `kubectl --context rancher-desktop cluster-info` to ensure that an appropriate
 version of the `kubectl` client is installed.
 
@@ -71,7 +70,7 @@ There are two directories that need to be populated in order for Rancher Desktop
 To populate a source disk (which we refer to here as `%SOURCEDISK%`, although it is probably some kind of removable medium like a USB thumb drive), you need the following files:
 
 * `k3s-versions.json` -- this file is created by Rancher Desktop. It reads a raw JSON file from `https://update.k3s.io/v1-release/channels` and converts it into a different kind of JSON file. Currently there is no utility to do that conversion; the easiest way to get this file is to run Rancher Desktop on a connected system and save the `CACHE/k3s-versions.json` file (see below for where `CACHE` exists on different platforms).
-* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases, and you'll want to download `k3s-airgap-images-amd64.tar` or `k3s-airgap-images-arm64.tar` (for AMD/intel and M1 machines respectively) for the versions you plan on working with. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
+* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases. You'll want to download either the `k3s-airgap-images-amd64.tar` for AMD/Intel machines, `k3s-airgap-images-arm64.tar` for M1 machines, or the respective `*.tar.zst` compressed tarball if you are using `k3s` v1.26.1 and above. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
 
 ```
 cd .../CACHE
@@ -167,4 +166,4 @@ wget -O %SOURCEDISK/kubectl1.22.1.exe https://dl.k8s.io/v1.22.1/bin/windows/amd6
 
 ##### A Note on Versions
 
-Kubectl clients are guaranteed to work with servers that are running the same MAJOR version and differ in the MINOR version by at most 1. So for example, if your organization is working with Kubernetes versions v1.21.x, v1.22.x, and v1.23.x, for any patch-version of `x`, you would only need to install `kubectl1.22.x` in the `.kuberlr` directory. But if you copy a `v1.24.x` of Kubernetes into the `CACHE` directory, you'll need to ensure there's a compatible `kubectl` in the `.kuberlr` directory as well (any of `v1.23.x`, `v1.24.x`, or `v1.25.x` would suffice). 
+Kubectl clients are guaranteed to work with servers that are running the same MAJOR version and differ in the MINOR version by at most 1. So for example, if your organization is working with Kubernetes versions v1.21.x, v1.22.x, and v1.23.x, for any patch-version of `x`, you would only need to install `kubectl1.22.x` in the `.kuberlr` directory. But if you copy a `v1.24.x` of Kubernetes into the `CACHE` directory, you'll need to ensure there's a compatible `kubectl` in the `.kuberlr` directory as well (any of `v1.23.x`, `v1.24.x`, or `v1.25.x` would suffice).

--- a/versioned_docs/version-latest/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-latest/how-to-guides/running-air-gapped.md
@@ -9,7 +9,6 @@ import TabsConstants from '@site/core/TabsConstants';
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 
-
 ### A Note for Windows users
 
 This document uses Powershell syntax for environment variables. If you're using the Command shell
@@ -25,7 +24,7 @@ There are two areas where Rancher Desktop assumes network availability and will 
 
 ### Existing Deployments
 
-If Rancher Desktop has been installed on a machine initially with networked access, it can 
+If Rancher Desktop has been installed on a machine initially with networked access, it can
 be run subsequently on that machine after network connectivity has been turned off. The main
 difference in core functionality is that the list of versions of Kubernetes available in drop-down menus
 is limited to those versions that have actually been downloaded and stored in the cache.
@@ -43,7 +42,7 @@ Suppose there are three versions of `k3s` in the `rancher-desktop` cache.
 
 - 1.19.16
 
-But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that 
+But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that
 the `~/.kuberlr/PLATFORM-ARCH/` directory (`$env:HOMEDRIVE%\$env:HOMEPATH/.kuberlr/windows-amd64` on Windows) will contain only two files:
 
 - kubectl1.24.3
@@ -54,7 +53,7 @@ If we go offline and use the UI to switch to Kubernetes `1.19.16`, when `kubectl
 The problem is that `kubectl` is an alias for `kuberlr`, which will try to download `kubectl 1.19.16` and install it
 in the `.kuberlr` directory, but won't be able to access it.
 
-So in this case, it would be best to prepare a connected system for disconnecting by selecting each available version of 
+So in this case, it would be best to prepare a connected system for disconnecting by selecting each available version of
 Kubernetes currently in the cache, and running `kubectl --context rancher-desktop cluster-info` to ensure that an appropriate
 version of the `kubectl` client is installed.
 
@@ -71,7 +70,7 @@ There are two directories that need to be populated in order for Rancher Desktop
 To populate a source disk (which we refer to here as `%SOURCEDISK%`, although it is probably some kind of removable medium like a USB thumb drive), you need the following files:
 
 * `k3s-versions.json` -- this file is created by Rancher Desktop. It reads a raw JSON file from `https://update.k3s.io/v1-release/channels` and converts it into a different kind of JSON file. Currently there is no utility to do that conversion; the easiest way to get this file is to run Rancher Desktop on a connected system and save the `CACHE/k3s-versions.json` file (see below for where `CACHE` exists on different platforms).
-* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases, and you'll want to download `k3s-airgap-images-amd64.tar` or `k3s-airgap-images-arm64.tar` (for AMD/intel and M1 machines respectively) for the versions you plan on working with. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
+* Tar archives of Kubernetes K3s images. These are listed at https://github.com/k3s-io/k3s/releases. You'll want to download either the `k3s-airgap-images-amd64.tar` for AMD/Intel machines, `k3s-airgap-images-arm64.tar` for M1 machines, or the respective `*.tar.zst` compressed tarball if you are using `k3s` v1.26.1 and above. Finally you'll need to download the `k3s` executable for the selected version. For example, the following commands will let you work with K3s v1.24.3 build 1 offline:
 
 ```
 cd .../CACHE
@@ -167,4 +166,4 @@ wget -O %SOURCEDISK/kubectl1.22.1.exe https://dl.k8s.io/v1.22.1/bin/windows/amd6
 
 ##### A Note on Versions
 
-Kubectl clients are guaranteed to work with servers that are running the same MAJOR version and differ in the MINOR version by at most 1. So for example, if your organization is working with Kubernetes versions v1.21.x, v1.22.x, and v1.23.x, for any patch-version of `x`, you would only need to install `kubectl1.22.x` in the `.kuberlr` directory. But if you copy a `v1.24.x` of Kubernetes into the `CACHE` directory, you'll need to ensure there's a compatible `kubectl` in the `.kuberlr` directory as well (any of `v1.23.x`, `v1.24.x`, or `v1.25.x` would suffice). 
+Kubectl clients are guaranteed to work with servers that are running the same MAJOR version and differ in the MINOR version by at most 1. So for example, if your organization is working with Kubernetes versions v1.21.x, v1.22.x, and v1.23.x, for any patch-version of `x`, you would only need to install `kubectl1.22.x` in the `.kuberlr` directory. But if you copy a `v1.24.x` of Kubernetes into the `CACHE` directory, you'll need to ensure there's a compatible `kubectl` in the `.kuberlr` directory as well (any of `v1.23.x`, `v1.24.x`, or `v1.25.x` would suffice).


### PR DESCRIPTION
This update is for what users should expect to download for their respective source disk `k3s` compressed tarball when preparing for an air-gapped system. Also some markdown cleanup across the files.