### PR TITLE
Document auto-start and background behavior settings

### DIFF
--- a/docs/ui/preferences/application.md
+++ b/docs/ui/preferences/application.md
@@ -10,20 +10,44 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-### Automatic Updates
+### General
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_application_tabGeneral.png)
+
+#### Automatic Updates
 
 When an update is available, users are provided a notification and the release notes for the upgrade target. This happens whether automatic updates are enabled or not. If this option is enabled, the update is downloaded and then installed the next time Rancher Desktop is started.
 
-### Statistics
+#### Statistics
 
 This option allows Rancher Desktop to collect information on how you interact with the Rancher Desktop application. Information such as what workloads you run are not collected.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_application.png)
+### Behavior
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_application_tabBehavior.png)
+
+#### Startup
+
+Rancher Desktop can automatically be started as part of the user login process. This will take all other behavior settings from the page into account as well.
+
+#### Background
+
+When Rancher Desktop is started in the background, it will not have an application window, nor an entry in the task switcher or task bar. The application window can still be opened via the context menu of the notification icon.
+
+When Rancher Desktop is launched again while already running in the background then the application window is shown and the application is added to the task switcher and task bar. This can be used to gain access to the background application again when the notification icon is unavailable as well.
+
+Rancher Desktop normally remains running in the background even when the main application window is closed (and the application therefore removed from the task switcher and task bar), but can be configured to terminate the application as well when the main window is closed.
+
+#### Notification Icon
+
+Rancher Desktop shows the application status with a notification icon. The context menu of the icon provides more status information and provides quick access to other functionality of the application. This options will disable the creation of the notification icon.
 
 </TabItem>
 <TabItem value="macOS">
 
-### Behavior
+### General
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -37,9 +61,30 @@ When an update is available, users are provided a notification and the release n
 
 This option allows Rancher Desktop to collect information on how you interact with the Rancher Desktop application. Information such as what workloads you run are not collected.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_application_tabBehavior.png)
+
+### Behavior
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabBehavior.png)
+
+#### Startup
+
+Rancher Desktop can automatically be started as part of the user login process. This will take all other behavior settings from the page into account as well.
+
+#### Background
+
+When Rancher Desktop is started in the background, it will not have an application window, nor an entry in the app switcher or the dock. The application window can still be opened via the context menu of the notification icon in the menu bar.
+
+When Rancher Desktop is launched again while already running in the background then the application window is shown and the application is added to the app switcher and the dock. This can be used to gain access to the background application again when the notification icon is unavailable as well.
+
+Rancher Desktop normally remains running in the background even when the main application window is closed (and the application therefore removed from the app switcher and the dock), but can be configured to terminate the application as well when the main window is closed.
+
+#### Notification Icon
+
+Rancher Desktop shows the application status with a notification icon in the menu bar. The context menu of the icon provides more status information and provides quick access to other functionality of the application. This options will disable the creation of the notification icon.
 
 ### Environment
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -51,13 +96,13 @@ There are two options for doing this:
 
 - **Automatic**: `PATH` management will add `~/.rd/bin` to your `PATH` by modifying your shell .rc files for you.
 - **Manual**: `PATH` management does not change anything - in this mode, you must add `~/.rd/bin` to your `PATH` yourself.
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_application_tabEnvironment.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-### Behavior
+### General
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -71,9 +116,29 @@ When an update is available, users are provided a notification and the release n
 
 This option allows Rancher Desktop to collect information on how you interact with the Rancher Desktop application. Information such as what workloads you run are not collected.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_application_tabBehavior.png)
+### Behavior
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabBehavior.png)
+
+#### Startup
+
+Rancher Desktop can automatically be started as part of the user login process. This will take all other behavior settings from the page into account as well.
+
+#### Background
+
+When Rancher Desktop is started in the background, it will not have an application window, nor an entry in the task switcher or task bar. The application window can still be opened via the context menu of the notification icon.
+
+When Rancher Desktop is launched again while already running in the background then the application window is shown and the application is added to the task switcher and task bar. This can be used to gain access to the background application again when the notification icon is unavailable as well.
+
+Rancher Desktop normally remains running in the background even when the main application window is closed (and the application therefore removed from the task switcher and task bar), but can be configured to terminate the application as well when the main window is closed.
+
+#### Notification Icon
+
+Rancher Desktop shows the application status with a notification icon. The context menu of the icon provides more status information and provides quick access to other functionality of the application. This options will disable the creation of the notification icon.
 
 ### Environment
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -85,8 +150,6 @@ There are two options for doing this:
 
 - **Automatic**: `PATH` management will add `~/.rd/bin` to your `PATH` by modifying your shell .rc files for you.
 - **Manual**: `PATH` management does not change anything - in this mode, you must add `~/.rd/bin` to your `PATH` yourself.
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_application_tabEnvironment.png)
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
The old "Behavior" tab is now called "General", and the new options are configurable on the second tab called "Behavior".

The documentation for the new Behavior tab has been duplicated from Windows to macOS and Linux. The macOS verbiage has been slightly adjusted to use OS-specific terms, like "app switcher" and "dock" instead of "task switcher" and "task bar". It also adds "in the menu bar" to "notification icon" because the concept is normally known as the "menu bar icon" on macOS.

The Linux version still uses Windows terminology; not sure if there is native terminology that is consistent across window managers.

This commit also moves the screenshots to the top of the section describing the individual settings.