### PR TITLE
Move screenshots before their descriptions

### DIFF
--- a/docs/ui/diagnostics.md
+++ b/docs/ui/diagnostics.md
@@ -7,13 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-**Note:** Rancher Desktop *doesn't* send the diagnostics data to any remote server for processing or storing.
-
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.
 
-The diagnostics checks are run every time when the application launches. If there are any problems identified then the count of failed checks is shown next to the *Diagnostics* menu text in the left navigation bar, indicating that something needs your attention. The *Diagnostics* tab displays the results of the diagnostics tests, highlighting areas that need attention, and guides you to resolve problems.
-
-On this tab you can mute/unmute individual checks if you have a non-standard setup and know that these checks don't apply to your situation. You can also rerun the diagnostics anytime to verify that changes you have made to your environment have rectified the problem.
+**Note:** Rancher Desktop *doesn't* send the diagnostics data to any remote server for processing or storing.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
@@ -32,3 +28,7 @@ On this tab you can mute/unmute individual checks if you have a non-standard set
 
 </TabItem>
 </Tabs>
+
+The diagnostics checks are run every time when the application launches. If there are any problems identified then the count of failed checks is shown next to the *Diagnostics* menu text in the left navigation bar, indicating that something needs your attention. The *Diagnostics* tab displays the results of the diagnostics tests, highlighting areas that need attention, and guides you to resolve problems.
+
+On this tab you can mute/unmute individual checks if you have a non-standard setup and know that these checks don't apply to your situation. You can also rerun the diagnostics anytime to verify that changes you have made to your environment have rectified the problem.

--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -7,13 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-To forward a port:
-
-1. Find the service and click **Forward**.
-1. Specify a port to use or use the randomly assigned port.
-1. Click the &check; button to confirm your selection.
-1. Optional: click **Cancel** to remove the port assigned.
-
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
@@ -31,3 +24,10 @@ To forward a port:
 
 </TabItem>
 </Tabs>
+
+To forward a port:
+
+1. Find the service and click **Forward**.
+1. Specify a port to use or use the randomly assigned port.
+1. Click the &check; button to confirm your selection.
+1. Optional: click **Cancel** to remove the port assigned.

--- a/docs/ui/preferences/container-engine.md
+++ b/docs/ui/preferences/container-engine.md
@@ -7,13 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-## General
+### General
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.
-
-When switching to a different container runtime:
-
-- Workloads and images that have been built or pulled using the existing container runtime are not available on the container runtime being switched to.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
@@ -33,13 +29,14 @@ When switching to a different container runtime:
 </TabItem>
 </Tabs>
 
-## Allowed Images
+#### Container Engine
+
+When switching to a different container runtime: Workloads and images that have been built or pulled using the current container runtime are not available on the container runtime being switched to.
+
+
+### Allowed Images
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.
-
-Check the **Enable** checkbox to enable Rancher Desktop to apply the specified patterns while pulling or pushing images, which means only images whose names match at least one of the specified patterns will be allowed.
-
-You can use the **+** and **-** buttons to add/remove image name patterns. 
 
 <Tabs groupId="os">
 <TabItem value="Windows">
@@ -59,7 +56,13 @@ You can use the **+** and **-** buttons to add/remove image name patterns.
 </TabItem>
 </Tabs>
 
-### How to specify Allowed Image patterns
+#### Allowed image patterns
+
+Check the **Enable** checkbox to enable Rancher Desktop to apply the specified patterns while pulling or pushing images, which means only images whose names match at least one of the specified patterns will be allowed.
+
+You can use the **+** and **-** buttons to add/remove image name patterns.
+
+##### How to specify Allowed Image patterns
 
 You can specify Allowed Image patterns using the format `[registry/][:port/][organization/]repository[:tag]`.
 
@@ -71,7 +74,7 @@ You can specify Allowed Image patterns using the format `[registry/][:port/][org
 
 **Note:** Filtering by `tag` does not actually work; the corresponding digests (`repository@digest`) will have to be added to the allow list as well, making this impractical. Please file a Github issue if you have a use-case that requires filtering based on tags!
 
-### Examples
+#### Examples
 
 | Pattern                   | Meaning                                                                                                                                                                                                             |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/ui/preferences/kubernetes.md
+++ b/docs/ui/preferences/kubernetes.md
@@ -7,13 +7,31 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-### Enable Kubernetes
+<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<TabItem value="Windows">
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_kubernetes.png)
+
+</TabItem>
+<TabItem value="macOS">
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_kubernetes.png)
+
+</TabItem>
+<TabItem value="Linux">
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_kubernetes.png)
+
+</TabItem>
+</Tabs>
+
+#### Enable Kubernetes
 
 This option allows you to enable or disable Kubernetes. By disabling Kubernetes, you can run just `containerd` or `dockerd` by itself for reduced resource consumption. By default, Kubernetes is enabled.
 
 To enable/disable Kubernetes, just check/uncheck the `Enable Kubernetes` checkbox. The app will be restarted when you enable/disable Kubernetes. Disabling Kubernetes will not delete existing resources and they will be available again when you enable Kubernetes again.
 
-### Kubernetes Version
+#### Kubernetes Version
 
 This option presents a list of Kubernetes versions that your Rancher Desktop instance can use.
 
@@ -33,30 +51,12 @@ To switch versions:
 1. Click the **Kubernetes version** drop-down menu.
 1. Select the version you want to change to.
 
-### Kubernetes Port
+#### Kubernetes Port
 
 Set the port Kubernetes is exposed on. Use this setting to avoid port collisions if multiple instances of K3s are running.
 
-### Enable Traefik
+#### Enable Traefik
 
 This option allows you to enable or disable Traefik. By disabling Traefik, you can free up port 80 and 443 for alternate ingress configuration. By default, Traefik is enabled.
 
 Disabling Traefik will not delete existing resources.
-
-<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
-<TabItem value="Windows">
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_kubernetes.png)
-
-</TabItem>
-<TabItem value="macOS">
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_kubernetes.png)
-
-</TabItem>
-<TabItem value="Linux">
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_kubernetes.png)
-
-</TabItem>
-</Tabs>

--- a/docs/ui/preferences/virtual-machine.md
+++ b/docs/ui/preferences/virtual-machine.md
@@ -7,14 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-### Memory
-
-The amount of memory to allocate to Rancher Desktop. The selectable range is based on your system. The red area within the range indicates an allocation that may affect system services.
-
-### CPUs
-
-The number of CPUs to allocate to Rancher Desktop. The selectable range is based on your system. The red area within the range indicates an allocation that may affect system services.
-
 <Tabs groupId="os">
 <TabItem value="macOS">
 
@@ -27,3 +19,11 @@ The number of CPUs to allocate to Rancher Desktop. The selectable range is based
 
 </TabItem>
 </Tabs>
+
+#### Memory
+
+The amount of memory to allocate to Rancher Desktop. The selectable range is based on your system. The red area within the range indicates an allocation that may affect system services.
+
+#### CPUs
+
+The number of CPUs to allocate to Rancher Desktop. The selectable range is based on your system. The red area within the range indicates an allocation that may affect system services.

--- a/docs/ui/troubleshooting.md
+++ b/docs/ui/troubleshooting.md
@@ -7,6 +7,24 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<TabItem value="Windows">
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Troubleshooting.png)
+
+</TabItem>
+<TabItem value="macOS">
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Troubleshooting.png)
+
+</TabItem>
+<TabItem value="Linux">
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Troubleshooting.png)
+
+</TabItem>
+</Tabs>
+
 ### Show Logs
 
 Use this option to open the folder containing all Rancher Desktop log files.
@@ -36,20 +54,3 @@ To perform a factory reset:
 1. Click **Factory Reset** to proceed. Kubernetes stops and Rancher Desktop closes.
 1. Optional: start Rancher Desktop again.
 
-<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
-<TabItem value="Windows">
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Troubleshooting.png)
-
-</TabItem>
-<TabItem value="macOS">
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Troubleshooting.png)
-
-</TabItem>
-<TabItem value="Linux">
-
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Troubleshooting.png)
-
-</TabItem>
-</Tabs>


### PR DESCRIPTION
In manuals you want to see the illustration first, and then read the description of the elements in the image. The general structure should be:

* introduction/overview
* screenshot
* detailed description of each element in the screenshot

This commit only moves text around, but doesn't change any.

It also normalizes some of the headings (for Preferences only):

Tab names are level 3 headings
Settings labels are level 4 headings