### PR TITLE
Don't create sample directories in the parent dir

### DIFF
--- a/docs/how-to-guides/hello-world-example.md
+++ b/docs/how-to-guides/hello-world-example.md
@@ -13,8 +13,8 @@ Rancher Desktop works with two container engines, [containerd](https://container
 
 #### Create a folder
 ```
-mkdir ../hello-world
-cd ../hello-world
+mkdir hello-world
+cd hello-world
 ```
 
 #### Create a blank Dockerfile
@@ -66,8 +66,8 @@ Make sure that you switch the **Container Runtime** setting in the **Kubernetes 
 
 #### Create a folder and add a sample index.html file as follows
 ```
-mkdir ../nginx
-cd ../nginx
+mkdir nginx
+cd nginx
 echo "<h1>Hello World from NGINX!!</h1>" > index.html
 ```
 


### PR DESCRIPTION
Not sure why the examples do this, but it makes no sense to me. And if you are in your `HOME` directory, then this won't even work:

```console
$ mkdir ../hello-world
mkdir: ../hello-world: Permission denied
```

This change should be applied to latest and older docs as well.