### PR TITLE
Automate updating rdctl sample command output

### DIFF
--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
 
 Run `rdctl` or `rdctl help` to see the list of available commands.
 
-```
+``` autoupdate=true
 > rdctl help
 The eventual goal of this CLI is to enable any UI-based operation to be done from the command-line as well.
 
@@ -49,10 +49,10 @@ Use "rdctl [command] --help" for more information about a command.
 
 ## rdctl api
 
-Run `rdctl api` to list all endpoints globally.
+Run `rdctl api /` to list all endpoints globally.
 
-```
-$ ../../../resources/darwin/bin/rdctl api / | jq -r .
+``` autoupdate=true
+$ rdctl api / | jq -r .[]
 [
   "GET /",
   "GET /v0",
@@ -63,10 +63,10 @@ $ ../../../resources/darwin/bin/rdctl api / | jq -r .
 ```
 ## rdctl api /vX
 
-Run `rdctl api /v0` to list all endpoints in a specified version.
+Run `rdctl api /v1` to list all endpoints in version 1.
 
-```
-$ rdctl api /v0 | jq -r .
+``` autoupdate=true
+$ rdctl api /v1 | jq -r .[]
 [
   "GET /v0",
   "GET /v0/settings",
@@ -97,7 +97,7 @@ but less concise and user-friendly.
 
 Run `rdctl list-settings` to see the current active configuration.
 
-```
+``` autoupdate=true
 > rdctl list-settings
 {
   "version": 4,
@@ -213,7 +213,7 @@ curl -s -H "Authorization: Basic $(echo -n "user:PASSWORD" | base64)"
 
 Run `rdctl version` to see the current rdctl CLI version.
 
-```
+``` autoupdate=true
 > rdctl version
 rdctl client version: 1.0.0, targeting server version: v0
 ```

--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -25,19 +25,19 @@ Usage:
   rdctl [command]
 
 Available Commands:
-  api           Runs API endpoints directly
-  api /vX       Enables you to see the endpoints for a particular version; e.g., v0
-  completion    Generates the autocompletion script for the specified shell
+  api           Run API endpoints directly
+  completion    Generate the autocompletion script for the specified shell
+  factory-reset Clear all the Rancher Desktop state and shut it down.
   help          Help about any command
-  list-settings Lists the current settings
-  set           Updates selected fields in the Rancher Desktop UI and restart the backend
+  list-settings Lists the current settings.
+  set           Update selected fields in the Rancher Desktop UI and restart the backend.
   shell         Run an interactive shell or a command in a Rancher Desktop-managed VM
   shutdown      Shuts down the running Rancher Desktop application
-  start         Start up Rancher Desktop or update its settings
-  version       Shows the CLI version
+  start         Start up Rancher Desktop, or update its settings.
+  version       Shows the CLI version.
 
 Flags:
-      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Roaming\rancher-desktop\rd-engine.json)
+      --config-path string   config file (default /Users/jan/Library/Application Support/rancher-desktop/rd-engine.json)
   -h, --help                 help for rdctl
       --host string          default is localhost; most useful for WSL
       --password string      overrides the password setting in the config file
@@ -53,13 +53,21 @@ Run `rdctl api /` to list all endpoints globally.
 
 ``` autoupdate=true
 $ rdctl api / | jq -r .[]
-[
-  "GET /",
-  "GET /v0",
-  "GET /v0/settings",
-  "PUT /v0/settings",
-  "PUT /v0/shutdown"
-]
+GET /
+GET /v0
+GET /v1
+GET /v1/about
+GET /v1/diagnostic_categories
+GET /v1/diagnostic_checks
+POST /v1/diagnostic_checks
+GET /v1/diagnostic_ids
+PUT /v1/factory_reset
+PUT /v1/propose_settings
+GET /v1/settings
+PUT /v1/settings
+PUT /v1/shutdown
+GET /v1/transient_settings
+PUT /v1/transient_settings
 ```
 ## rdctl api /vX
 
@@ -67,12 +75,19 @@ Run `rdctl api /v1` to list all endpoints in version 1.
 
 ``` autoupdate=true
 $ rdctl api /v1 | jq -r .[]
-[
-  "GET /v0",
-  "GET /v0/settings",
-  "PUT /v0/settings",
-  "PUT /v0/shutdown"
-]
+GET /v1
+GET /v1/about
+GET /v1/diagnostic_categories
+GET /v1/diagnostic_checks
+POST /v1/diagnostic_checks
+GET /v1/diagnostic_ids
+PUT /v1/factory_reset
+PUT /v1/propose_settings
+GET /v1/settings
+PUT /v1/settings
+PUT /v1/shutdown
+GET /v1/transient_settings
+PUT /v1/transient_settings
 ```
 ## rdctl api /v0/settings
 
@@ -100,18 +115,51 @@ Run `rdctl list-settings` to see the current active configuration.
 ``` autoupdate=true
 > rdctl list-settings
 {
-  "version": 4,
-  "kubernetes": {
-    "version": "1.22.7",
-    "memoryInGB": 2,
+  "version": 6,
+  "application": {
+    "adminAccess": false,
+    "pathManagementStrategy": "rcfiles",
+    "updater": {
+      "enabled": false
+    },
+    "debug": false,
+    "telemetry": {
+      "enabled": true
+    },
+    "autoStart": false,
+    "startInBackground": false,
+    "hideNotificationIcon": false,
+    "window": {
+      "quitOnClose": false
+    }
+  },
+  "virtualMachine": {
+    "memoryInGB": 6,
     "numberCPUs": 2,
+    "hostResolver": true
+  },
+  "WSL": {
+    "integrations": {}
+  },
+  "containerEngine": {
+    "allowedImages": {
+      "enabled": false,
+      "patterns": [
+        "docker.io"
+      ]
+    },
+    "name": "moby"
+  },
+  "kubernetes": {
+    "version": "",
     "port": 6443,
-    "containerEngine": "moby",
-    "checkForExistingKimBuilder": false,
-    "enabled": true,
-    "WSLIntegrations": {},
+    "enabled": false,
     "options": {
-      "traefik": true
+      "traefik": true,
+      "flannel": true
+    },
+    "ingress": {
+      "localhostOnly": false
     }
   },
   "portForwarding": {
@@ -121,10 +169,32 @@ Run `rdctl list-settings` to see the current active configuration.
     "showAll": true,
     "namespace": "k8s.io"
   },
-  "telemetry": true,
-  "updater": true,
-  "debug": false
+  "diagnostics": {
+    "showMuted": false,
+    "mutedChecks": {}
+  },
+  "experimental": {
+    "virtualMachine": {
+      "type": "qemu",
+      "useRosetta": false,
+      "socketVMNet": false,
+      "mount": {
+        "type": "reverse-sshfs",
+        "9p": {
+          "securityModel": "none",
+          "protocolVersion": "9p2000.L",
+          "msizeInKB": 128,
+          "cacheMode": "mmap"
+        }
+      },
+      "networkingTunnel": false
+    }
+  },
+  "extensions": {
+    "docker/logs-explorer-extension:0.2.2": true
+  }
 }
+
 ``` 
   </TabItem>
   <TabItem value="API" default>
@@ -215,5 +285,5 @@ Run `rdctl version` to see the current rdctl CLI version.
 
 ``` autoupdate=true
 > rdctl version
-rdctl client version: 1.0.0, targeting server version: v0
+rdctl client version: 1.1.0, targeting server version: v1
 ```

--- a/scripts/update-codeblocks
+++ b/scripts/update-codeblocks
@@ -1,0 +1,160 @@
+#!/usr/bin/env perl
+
+=pod
+
+update-codeblocks
+
+The purpose of this tool is to updates console codeblocks in markdown files
+by re-running embedded shell commands and updating their output, to automatically
+update documentation to the latest versions of the utilities used.
+
+Updated content is written to STDOUT unless the --update option is used, in which
+case the existing file is updated in-place. Make sure the original content is
+stored in the repo, in case something goes wrong.
+
+Only codeblocks with the `autoupdate=true` attribute are updated:
+
+```console autoupdate=true comment="#"
+Any text before the first command is copied verbatim. Command start with
+either the '>' or '$' characters:
+
+> date
+Sun 26 Mar 2023 21:22:48 PDT
+
+
+$ ls
+If the first line after the command includes the yada yada yada symbol (...)
+then the output is not replaced. The command is still executed though.
+
+The sharp-eyed reader will have noticed that the empty lines in front of this
+command have been preserved even though they were not part of the `date` output.
+
+This tool understands continuation lines:
+
+$ bash -c \
+  "echo Hi there!"
+Oh, hello, this line will be updated when the command is re-run.
+
+# It is possible to define a "comment" character/string. Only the text before
+the first comment line is replaced with the new command output.
+
+Here-documents are also supported:
+
+$ cat <<EOT
+foobar
+EOT
+foobar
+```
+
+Note that the embedded example above can be updated with this tool as well:
+
+```
+./scripts/update-codeblocks --update ./scripts/update-codeblocks
+git diff
+```
+
+=cut
+
+use strict;
+use warnings;
+
+use constant {
+    COPY    => "copy",
+    UPDATE  => "update",
+    COMMAND => "command",
+    HEREDOC => "heredoc",
+    CAPTURE => "capture",
+    SKIP    => "SKIP",
+};
+
+my $command;
+my $comment;
+my $debug = 0;
+my $heredoc;
+my $newlines = 0;
+my $output = "";
+my $update;
+
+$update = shift if @ARGV && $ARGV[0] eq "--update";
+
+my $state = COPY;
+while (<>) {
+    if ($state eq COPY) {
+        if (/^```.*autoupdate=true/) {
+            $comment = /comment="(.*?)"/ ? $1 : "";
+            $state = UPDATE;
+        }
+    }
+    elsif ($state eq UPDATE || $state eq SKIP) {
+        # stop skipping lines once a comment is encountered
+        $state = UPDATE if $comment && /^\Q$comment/;
+        if (/^[>\$]\s*(.*)/) {
+            $command = $1;
+            $state = COMMAND;
+        }
+        if (/^```/) {
+            $state = COPY;
+        }
+        if ($state eq UPDATE || $state eq COMMAND) {
+            # preserve trailing newlines of skipped output
+            $output .= "\n" x $newlines;
+            $newlines = 0;
+        }
+        if ($state eq SKIP) {
+            if (/^\s*$/) {
+                $newlines++;
+            } else {
+                $newlines = 0;
+            }
+            next;
+        }
+    }
+    elsif ($state eq COMMAND) {
+        if ($command =~ /\\$/) {
+            # append continuation line
+            $command .= "\n$_";
+            chomp $command;
+        } else {
+            if ($command =~ /<<(\w+)/) {
+                # continue appending lines until we hit the heredoc delimiter
+                $heredoc = $1;
+                $state = HEREDOC;
+            } else {
+                $state = CAPTURE;
+            }
+            redo;
+        }
+    }
+    elsif ($state eq HEREDOC) {
+        $command .= "\n$_";
+        chomp $command;
+        if (/^$heredoc$/) {
+            $state = CAPTURE;
+        }
+    }
+    elsif ($state eq CAPTURE) {
+        $output .= ">>> $command <<<\n" if $debug;
+        my $capture = qx[$command];
+        if (/\.\.\./) {
+            # if first line after command contains "..." then don't replace the output
+            $state = UPDATE;
+        } else {
+            $output .= $capture;
+            $state = SKIP;
+            redo;
+        }
+    }
+    else {
+        die "Unexpected state $state\n";
+    }
+    $output .= "[$state]" if $debug;
+    $output .= $_;
+    if (eof) {
+        if ($update) {
+            # Overwrite the input file
+            open STDOUT, ">", $ARGV or die;
+        }
+        print $output;
+        $output = "";
+    }
+}


### PR DESCRIPTION
This PR adds a script to re-run commands in code blocks inside the documentation to update their output using the latest version of the commands (usually `rdctl`).

It is best reviewed commit-by-commit:

1. Add `update-codeblocks` script
2. Annotate `rdctl-command-reference.md` with `autoupdate=true` attributes
3. Run `./scripts/update-codeblocks --update docs/references/rdctl-command-reference.md`

The tools is just an initial experiment. It doesn't handle errors/STDERR in the command output correctly in all cases.

It may also need to be rewritten in e.g. Ruby because the rest of the Rancher Desktop team is not really comfortable maintaining Perl scripts (but maybe the docs team is?).

Fixes #173 
