### PR TITLE
Updating bundled utilities v1.8 for the `next` version

### DIFF
--- a/docs/references/bundled-utilities.md
+++ b/docs/references/bundled-utilities.md
@@ -4,11 +4,13 @@ title: Bundled Utilities
 
 import Version160 from '../bundled-utilities-version-info/v1.6.0.md';
 import Version170 from '../bundled-utilities-version-info/v1.7.0.md';
+import Version180 from '../bundled-utilities-version-info/v1.8.0.md';
 
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |
 | ------------- | ---------------- |
+| v1.8.0 | <Version180 /> |
 | v1.7.0 | <Version170 /> |
 | v1.6.2 | There are no updated dependencies in the 1.6.2 release |
 | v1.6.1 | There are no updated dependencies in the 1.6.1 release |

--- a/docs/references/bundled-utilities.md
+++ b/docs/references/bundled-utilities.md
@@ -10,6 +10,7 @@ Rancher Desktop uses several utilities/subsystems as dependencies under the hood
 
 | Rancher Desktop Version | Dependency Versions |
 | ------------- | ---------------- |
+| v1.8.1 | There are no updated dependencies in the 1.8.1 release |
 | v1.8.0 | <Version180 /> |
 | v1.7.0 | <Version170 /> |
 | v1.6.2 | There are no updated dependencies in the 1.6.2 release |


### PR DESCRIPTION
The next version bundled utilities v1.8 was missing, updated to sync up properly with all versions.