### PR TITLE
Updates GTM tracking to correct container ID

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,7 +48,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         gtag: {
-          trackingID: 'GTM-57KS2MW',
+          trackingID: 'GTM-WQC3254',
         },
       }),
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,8 +47,8 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-        gtag: {
-          trackingID: 'GTM-WQC3254',
+        googleTagManager: {
+          containerId: 'GTM-57KS2MW',
         },
       }),
     ],


### PR DESCRIPTION
This PR updates the tracking ID for the Google tag per Jira SD-101310. 
Context [slack thread](https://suse.slack.com/archives/C02DQMPRA1E/p1680246378430449).