### PR TITLE
Remove Banner for v1.8

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,6 +41,11 @@ const config = {
               label: "1.9-tech-preview",
               path: "1.9-tech-preview",
               banner: "none"
+            },
+            1.8: {
+              label: "1.8",
+              path: "1.8",
+              banner: "none"
             }
           },
         },


### PR DESCRIPTION
Updating the `docusaurus.config` file to remove the banner for v1.8 docs showing "...no longer actively maintained".