### PR TITLE
Troubleshooting Tip Dev-Containers

### DIFF
--- a/docs/troubleshooting-tips.md
+++ b/docs/troubleshooting-tips.md
@@ -8,6 +8,20 @@ import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 
+#### Q: How can I fix the Docker error when starting a container using the VS Code dev-containers extension with version >`v0.266`?
+
+**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by either unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`, or by adding a customized setting to your VS code user `settings.json`. An example of the disabled setting is provided below:
+
+```
+"customizations": {
+   "vscode": {
+     "settings": {
+       "dev.containers.mountWaylandSocket": false
+     }
+   }
+ }
+ ```
+
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?
 
 **A:** You are likely using a WSL 1 distro. Rancher Desktop supports only WSL 2 distros. You can convert your WSL 1 distro into a WSL 2 distro by running the command `wsl --set-version <distro-name> 2`. You can also run the command `wsl --set-default-version 2` to set all the future distributions you might install to use WSL 2.

--- a/docs/troubleshooting-tips.md
+++ b/docs/troubleshooting-tips.md
@@ -10,17 +10,7 @@ This page provides tips to troubleshoot issues you may have with Rancher Desktop
 
 #### Q: How can I fix the Docker error when starting a container using the VS Code dev-containers extension with version >`v0.266`?
 
-**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by either unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`, or by adding a customized setting to your VS code user `settings.json`. An example of the disabled setting is provided below:
-
-```
-"customizations": {
-   "vscode": {
-     "settings": {
-       "dev.containers.mountWaylandSocket": false
-     }
-   }
- }
- ```
+**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`.
 
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?
 

--- a/versioned_docs/version-1.8/troubleshooting-tips.md
+++ b/versioned_docs/version-1.8/troubleshooting-tips.md
@@ -8,6 +8,20 @@ import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 
+#### Q: How can I fix the Docker error when starting a container using the VS Code dev-containers extension with version >`v0.266`?
+
+**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by either unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`, or by adding a customized setting to your VS code user `settings.json`. An example of the disabled setting is provided below:
+
+```
+"customizations": {
+   "vscode": {
+     "settings": {
+       "dev.containers.mountWaylandSocket": false
+     }
+   }
+ }
+ ```
+
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?
 
 **A:** You are likely using a WSL 1 distro. Rancher Desktop supports only WSL 2 distros. You can convert your WSL 1 distro into a WSL 2 distro by running the command `wsl --set-version <distro-name> 2`. You can also run the command `wsl --set-default-version 2` to set all the future distributions you might install to use WSL 2.

--- a/versioned_docs/version-1.8/troubleshooting-tips.md
+++ b/versioned_docs/version-1.8/troubleshooting-tips.md
@@ -10,17 +10,7 @@ This page provides tips to troubleshoot issues you may have with Rancher Desktop
 
 #### Q: How can I fix the Docker error when starting a container using the VS Code dev-containers extension with version >`v0.266`?
 
-**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by either unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`, or by adding a customized setting to your VS code user `settings.json`. An example of the disabled setting is provided below:
-
-```
-"customizations": {
-   "vscode": {
-     "settings": {
-       "dev.containers.mountWaylandSocket": false
-     }
-   }
- }
- ```
+**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`.
 
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?
 

--- a/versioned_docs/version-latest/troubleshooting-tips.md
+++ b/versioned_docs/version-latest/troubleshooting-tips.md
@@ -8,6 +8,20 @@ import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 
+#### Q: How can I fix the Docker error when starting a container using the VS Code dev-containers extension with version >`v0.266`?
+
+**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by either unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`, or by adding a customized setting to your VS code user `settings.json`. An example of the disabled setting is provided below:
+
+```
+"customizations": {
+   "vscode": {
+     "settings": {
+       "dev.containers.mountWaylandSocket": false
+     }
+   }
+ }
+ ```
+
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?
 
 **A:** You are likely using a WSL 1 distro. Rancher Desktop supports only WSL 2 distros. You can convert your WSL 1 distro into a WSL 2 distro by running the command `wsl --set-version <distro-name> 2`. You can also run the command `wsl --set-default-version 2` to set all the future distributions you might install to use WSL 2.

--- a/versioned_docs/version-latest/troubleshooting-tips.md
+++ b/versioned_docs/version-latest/troubleshooting-tips.md
@@ -10,17 +10,7 @@ This page provides tips to troubleshoot issues you may have with Rancher Desktop
 
 #### Q: How can I fix the Docker error when starting a container using the VS Code dev-containers extension with version >`v0.266`?
 
-**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by either unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`, or by adding a customized setting to your VS code user `settings.json`. An example of the disabled setting is provided below:
-
-```
-"customizations": {
-   "vscode": {
-     "settings": {
-       "dev.containers.mountWaylandSocket": false
-     }
-   }
- }
- ```
+**A:** There is a current workaround for users experiencing a Docker error when starting a container using the dev-containers extension for VS code versioned `v0.266` or later and Rancher Desktop `v1.8.1`. Disabling Wayland in the user settings will allow the container to spin up successfully. This can be accomplished by unchecking the box in the `Settings` > `Extensions` > `Dev Containers` tab labelled `Dev > Containers: Mount Wayland Socket (Applies to All Profiles)`.
 
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?
 


### PR DESCRIPTION
Adding a troubleshooting tip for users seeing a Docker error when starting a container in VS code using the dev-containers extension >v0.266. This is tied to [4436](https://github.com/rancher-sandbox/rancher-desktop/issues/4436) on RD.