### PR TITLE
Update Top Navbar with Quick Links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,6 +88,26 @@ const config = {
         },
         items: [
           {
+            type: `dropdown`,
+            label: `Quick Links`,
+            position: `right`,
+            items: [
+              {
+                href: 'https://rancherdesktop.io/',
+                label: 'Rancher Desktop Home',
+                target: '_self',
+              },
+              {
+                href: 'https://github.com/rancher-sandbox/rancher-desktop/',
+                label: 'GitHub',
+              },
+              {
+                href: 'https://github.com/rancher-sandbox/docs.rancherdesktop.io/',
+                label: 'Docs GitHub',
+              },
+            ]
+          },
+          {
             type: 'docsVersionDropdown',
             position: 'left',
             dropdownActiveClassDisabled: true,
@@ -95,22 +115,6 @@ const config = {
           {
             type: "localeDropdown",
             position: "right",
-          },
-          {
-            href: 'https://rancherdesktop.io/',
-            label: 'Rancher Desktop Home',
-            target: '_self',
-            position: 'right',
-          },
-          {
-            href: 'https://github.com/rancher-sandbox/rancher-desktop/',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            href: 'https://github.com/rancher-sandbox/docs.rancherdesktop.io/',
-            label: 'Docs GitHub',
-            position: 'right',
           },
         ],
       },


### PR DESCRIPTION
Updating the top nav bar to have a dropdown labeled Quick Links that holds the RD Home, RD GitHub, and RD Docs GitHub links so as to synthesize/organize top level links.