### PR TITLE
WSL - Proxy and Integrations Page Update 

### DIFF
--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -1,4 +1,4 @@
 ---
 sidebar_label: Integrations
-title: Integrations (Windows)
+title: Integrations
 ---

--- a/docs/ui/preferences/wsl/proxy.md
+++ b/docs/ui/preferences/wsl/proxy.md
@@ -1,0 +1,4 @@
+---
+sidebar_label: Proxy
+title: Proxy
+---

--- a/sidebars.js
+++ b/sidebars.js
@@ -60,7 +60,8 @@ const sidebars = {
               label: 'WSL',
               items:  [
                 "ui/preferences/wsl/integrations",
-                "ui/preferences/wsl/network"
+                "ui/preferences/wsl/network",
+                "ui/preferences/wsl/proxy"
               ]
             },
           ],

--- a/versioned_docs/version-1.9/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.9/ui/preferences/wsl/integrations.md
@@ -1,4 +1,4 @@
 ---
 sidebar_label: Integrations
-title: Integrations (Windows)
+title: Integrations
 ---

--- a/versioned_docs/version-1.9/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.9/ui/preferences/wsl/proxy.md
@@ -1,0 +1,4 @@
+---
+sidebar_label: Proxy
+title: Proxy
+---

--- a/versioned_sidebars/version-1.9-sidebars.json
+++ b/versioned_sidebars/version-1.9-sidebars.json
@@ -41,7 +41,8 @@
               "label": "WSL",
               "items": [
                 "ui/preferences/wsl/integrations",
-                "ui/preferences/wsl/network"
+                "ui/preferences/wsl/network",
+                "ui/preferences/wsl/proxy"
               ]
             }
           ]


### PR DESCRIPTION
Adding the proxy page skeleton and updating the sidebars. Additionally updating the integrations page to remove redundancy as the integrations page is only present on the WSL tab. This is tied to [issue 4719](https://github.com/rancher-sandbox/rancher-desktop/issues/4719).