### PR TITLE
Update Port Forward - Port Mappings

### DIFF
--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -36,4 +36,10 @@ The steps below outline how to forward a port:
 
 ### Admin vs Non-Admin Port Mappings
 
-Rancher Desktop includes automated port forwarding for versions `1.9` and later. For a non-admin Rancher Desktop installation, the port mappings are configured to the localhost and ports > 1024. If you have an admin Rancher Desktop installation, then port mappings can be configured for priviliged ports <= 1024 as well.
+Rancher Desktop includes automated port forwarding for versions `1.9` and later. For non-admin port access, port mappings are configured to the localhost and unpriviliged ports > 1024. Priviliged port mappings can also be configured by users with admin permissions for ports <= 1024.
+
+:::note
+
+Please see [Traefik Port Binding Access](../getting-started/installation#traefik-port-binding-access) to configure ports at the operating system level.
+
+:::

--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -25,9 +25,15 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 </Tabs>
 
-To forward a port:
+### How to Forward a Port
+
+The steps below outline how to forward a port:
 
 1. Find the service and click **Forward**.
 1. Specify a port to use or use the randomly assigned port.
 1. Click the &check; button to confirm your selection.
 1. Optional: click **Cancel** to remove the port assigned.
+
+### Admin vs Non-Admin Port Mappings
+
+Rancher Desktop includes automated port forwarding for versions `1.9` and later. For a non-admin Rancher Desktop installation, the port mappings are configured to the localhost and ports > 1024. If you have an admin Rancher Desktop installation, then port mappings can be configured for priviliged ports <= 1024 as well.

--- a/versioned_docs/version-1.9/ui/port-forwarding.md
+++ b/versioned_docs/version-1.9/ui/port-forwarding.md
@@ -36,4 +36,10 @@ The steps below outline how to forward a port:
 
 ### Admin vs Non-Admin Port Mappings
 
-Rancher Desktop includes automated port forwarding for versions `1.9` and later. For a non-admin Rancher Desktop installation, the port mappings are configured to the localhost and ports > 1024. If you have an admin Rancher Desktop installation, then port mappings can be configured for priviliged ports <= 1024 as well.
+Rancher Desktop includes automated port forwarding for versions `1.9` and later. For non-admin port access, port mappings are configured to the localhost and unpriviliged ports > 1024. Priviliged port mappings can also be configured by users with admin permissions for ports <= 1024.
+
+:::note
+
+Please see [Traefik Port Binding Access](../getting-started/installation#traefik-port-binding-access) to configure ports at the operating system level.
+
+:::

--- a/versioned_docs/version-1.9/ui/port-forwarding.md
+++ b/versioned_docs/version-1.9/ui/port-forwarding.md
@@ -25,9 +25,15 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 </Tabs>
 
-To forward a port:
+### How to Forward a Port
+
+The steps below outline how to forward a port:
 
 1. Find the service and click **Forward**.
 1. Specify a port to use or use the randomly assigned port.
 1. Click the &check; button to confirm your selection.
 1. Optional: click **Cancel** to remove the port assigned.
+
+### Admin vs Non-Admin Port Mappings
+
+Rancher Desktop includes automated port forwarding for versions `1.9` and later. For a non-admin Rancher Desktop installation, the port mappings are configured to the localhost and ports > 1024. If you have an admin Rancher Desktop installation, then port mappings can be configured for priviliged ports <= 1024 as well.


### PR DESCRIPTION
Updating the port forward page with section on port mappings for admin vs non-admin installations, and updated the headers to improve readability. This addresses [issue 4296](https://github.com/rancher-sandbox/rancher-desktop/issues/4296).