### PR TITLE
V1.9 WSL Tabs - Integrations, Networking

### DIFF
--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -2,3 +2,15 @@
 sidebar_label: Integrations
 title: Integrations
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/wsl/Windows_WSL_tabIntegrations.png)
+
+With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
+
+[WSL documentation]:
+https://docs.microsoft.com/en-us/windows/wsl/wsl-config#options-for-wslconfig

--- a/docs/ui/preferences/wsl/network.md
+++ b/docs/ui/preferences/wsl/network.md
@@ -2,3 +2,15 @@
 sidebar_label: Network
 title: Network (Windows)
 ---
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/wsl/Windows_WSL_tabNetwork_checked.png)
+
+### Networking Tunnel
+
+:::caution warning
+
+This is an **experimental** setting.
+
+:::
+
+Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the experimental Rancher Desktop Network.

--- a/versioned_docs/version-1.9/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.9/ui/preferences/wsl/integrations.md
@@ -2,3 +2,15 @@
 sidebar_label: Integrations
 title: Integrations
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/wsl/Windows_WSL_tabIntegrations.png)
+
+With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
+
+[WSL documentation]:
+https://docs.microsoft.com/en-us/windows/wsl/wsl-config#options-for-wslconfig

--- a/versioned_docs/version-1.9/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.9/ui/preferences/wsl/network.md
@@ -2,3 +2,15 @@
 sidebar_label: Network
 title: Network (Windows)
 ---
+
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/wsl/Windows_WSL_tabNetwork_checked.png)
+
+### Networking Tunnel
+
+:::caution warning
+
+This is an **experimental** setting.
+
+:::
+
+Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the experimental Rancher Desktop Network.


### PR DESCRIPTION
Adding screenshots and descriptions for Network and Integrations tab. Screenshots will be updated in S3 once updated screenshots are received but URL addresses should remain unchanged. This is tied to [4719](https://github.com/rancher-sandbox/rancher-desktop/issues/4719) and [4635](https://github.com/rancher-sandbox/rancher-desktop/issues/4635).