### PR TITLE
Add Canonical Links Pt 2

### DIFF
--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
+</head>
+
 Deployment profiles provide 2 features:
 
 * "Defaults" provide preference values that are applied on first run (or after a factory reset).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
+</head>
+
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -7,6 +7,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
+</head>
+
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)

--- a/docs/tutorials/working-with-containers.md
+++ b/docs/tutorials/working-with-containers.md
@@ -5,6 +5,10 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
+</head>
+
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/docs/tutorials/working-with-images.md
+++ b/docs/tutorials/working-with-images.md
@@ -5,6 +5,10 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
+</head>
+
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.6/getting-started/installation.md
+++ b/versioned_docs/version-1.6/getting-started/installation.md
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
+</head>
+
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.6/getting-started/introduction.md
+++ b/versioned_docs/version-1.6/getting-started/introduction.md
@@ -3,6 +3,10 @@ title: Introduction
 slug: /
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
+</head>
+
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](../img/intro/intro.png)

--- a/versioned_docs/version-1.6/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.6/tutorials/working-with-containers.md
@@ -5,6 +5,10 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
+</head>
+
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.6/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.6/tutorials/working-with-images.md
@@ -5,6 +5,10 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
+</head>
+
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.7/getting-started/installation.md
+++ b/versioned_docs/version-1.7/getting-started/installation.md
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
+</head>
+
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.7/getting-started/introduction.md
+++ b/versioned_docs/version-1.7/getting-started/introduction.md
@@ -3,6 +3,10 @@ title: Introduction
 slug: /
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
+</head>
+
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](../img/intro/intro.png)

--- a/versioned_docs/version-1.7/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.7/tutorials/working-with-containers.md
@@ -5,6 +5,10 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
+</head>
+
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.7/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.7/tutorials/working-with-images.md
@@ -5,6 +5,10 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
+</head>
+
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.8/getting-started/deployment.md
+++ b/versioned_docs/version-1.8/getting-started/deployment.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
+</head>
+
 Deployment profiles provide 2 features:
 
 * "Defaults" provide preference values that are applied on first run (or after a factory reset).

--- a/versioned_docs/version-1.8/getting-started/installation.md
+++ b/versioned_docs/version-1.8/getting-started/installation.md
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
+</head>
+
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.8/getting-started/introduction.md
+++ b/versioned_docs/version-1.8/getting-started/introduction.md
@@ -3,6 +3,10 @@ title: Introduction
 slug: /
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
+</head>
+
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](../img/intro/intro.png)

--- a/versioned_docs/version-1.8/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.8/tutorials/working-with-containers.md
@@ -5,6 +5,10 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
+</head>
+
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.8/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.8/tutorials/working-with-images.md
@@ -5,6 +5,10 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
+</head>
+
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.9/getting-started/deployment.md
+++ b/versioned_docs/version-1.9/getting-started/deployment.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
+</head>
+
 Deployment profiles provide 2 features:
 
 * "Defaults" provide preference values that are applied on first run (or after a factory reset).

--- a/versioned_docs/version-1.9/getting-started/installation.md
+++ b/versioned_docs/version-1.9/getting-started/installation.md
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
+</head>
+
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.9/getting-started/introduction.md
+++ b/versioned_docs/version-1.9/getting-started/introduction.md
@@ -3,6 +3,10 @@ title: Introduction
 slug: /
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
+</head>
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';

--- a/versioned_docs/version-1.9/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.9/tutorials/working-with-containers.md
@@ -5,6 +5,10 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
+</head>
+
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.9/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.9/tutorials/working-with-images.md
@@ -5,6 +5,10 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
+</head>
+
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 


### PR DESCRIPTION
Part 2 of adding canonical links for SEO improvement with Rancher Desktop. This PR affects all pages in the Getting Started and Tutorials drop-down.