### PR TITLE
Add Canonical Links Pt 3

### DIFF
--- a/docs/how-to-guides/create-multi-node-cluster.md
+++ b/docs/how-to-guides/create-multi-node-cluster.md
@@ -5,6 +5,10 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
+</head>
+
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/docs/how-to-guides/hello-world-example.md
+++ b/docs/how-to-guides/hello-world-example.md
@@ -5,6 +5,10 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
+</head>
+
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/docs/how-to-guides/increasing-open-file-limit.md
+++ b/docs/how-to-guides/increasing-open-file-limit.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
+</head>
+
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/docs/how-to-guides/installing-uninstalling-extensions.md
+++ b/docs/how-to-guides/installing-uninstalling-extensions.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
+</head>
+
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.
 
 ### Prerequisites

--- a/docs/how-to-guides/transfer-container-images.md
+++ b/docs/how-to-guides/transfer-container-images.md
@@ -5,6 +5,10 @@ title: Transfer Container Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
+</head>
+
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.6/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.6/how-to-guides/create-multi-node-cluster.md
@@ -5,6 +5,10 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
+</head>
+
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.6/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.6/how-to-guides/hello-world-example.md
@@ -5,6 +5,10 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
+</head>
+
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.6/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.6/how-to-guides/increasing-open-file-limit.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
+</head>
+
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.7/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.7/how-to-guides/create-multi-node-cluster.md
@@ -5,6 +5,10 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
+</head>
+
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.7/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.7/how-to-guides/hello-world-example.md
@@ -5,6 +5,10 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
+</head>
+
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.7/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.7/how-to-guides/increasing-open-file-limit.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
+</head>
+
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.7/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.7/how-to-guides/transfer-container-images.md
@@ -5,6 +5,10 @@ title: Transfer Container Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
+</head>
+
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.8/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.8/how-to-guides/create-multi-node-cluster.md
@@ -5,6 +5,10 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
+</head>
+
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.8/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.8/how-to-guides/hello-world-example.md
@@ -5,6 +5,10 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
+</head>
+
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.8/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.8/how-to-guides/increasing-open-file-limit.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
+</head>
+
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.8/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.8/how-to-guides/transfer-container-images.md
@@ -5,6 +5,10 @@ title: Transfer Container Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
+</head>
+
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.9/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.9/how-to-guides/create-multi-node-cluster.md
@@ -5,6 +5,10 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
+</head>
+
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.9/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.9/how-to-guides/hello-world-example.md
@@ -5,6 +5,10 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
+</head>
+
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.9/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.9/how-to-guides/increasing-open-file-limit.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
+</head>
+
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
+</head>
+
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.
 
 ### Prerequisites

--- a/versioned_docs/version-1.9/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.9/how-to-guides/transfer-container-images.md
@@ -5,6 +5,10 @@ title: Transfer Container Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
+</head>
+
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps


### PR DESCRIPTION
Updating canonical links for how-to pages, partial amount of pages across all non-latest versions were updated to keep review manageable. This is tied to #245.