### PR TITLE
Add Canonical Links Pt 4

### DIFF
--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
+</head>
+
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/docs/how-to-guides/rancher-on-rancher-desktop.md
+++ b/docs/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
+</head>
+
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/docs/how-to-guides/running-air-gapped.md
+++ b/docs/how-to-guides/running-air-gapped.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
+</head>
+
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,6 +5,10 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
+</head>
+
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.6/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.6/how-to-guides/provisioning-scripts.md
@@ -5,6 +5,10 @@ title: Provisioning Scripts
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
+</head>
+
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/versioned_docs/version-1.6/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.6/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
+</head>
+
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.6/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.6/how-to-guides/running-air-gapped.md
@@ -5,6 +5,10 @@ title: Running When Offline
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
+</head>
+
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.6/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.6/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,6 +5,10 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
+</head>
+
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
+</head>
+
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/versioned_docs/version-1.7/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.7/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
+</head>
+
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.7/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.7/how-to-guides/running-air-gapped.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
+</head>
+
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.7/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.7/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,6 +5,10 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
+</head>
+
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.8/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.8/how-to-guides/provisioning-scripts.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
+</head>
+
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/versioned_docs/version-1.8/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.8/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
+</head>
+
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.8/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.8/how-to-guides/running-air-gapped.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
+</head>
+
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.8/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.8/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,6 +5,10 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
+</head>
+
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
+</head>
+
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/versioned_docs/version-1.9/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.9/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
+</head>
+
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.9/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.9/how-to-guides/running-air-gapped.md
@@ -6,6 +6,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
+</head>
+
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.9/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.9/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,6 +5,10 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
+</head>
+
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps


### PR DESCRIPTION
Adding canonical links to how-to section pages in Rancher Desktop. This is tied to #245.