### PR TITLE
Add Canonical Links Pt 5

### DIFF
--- a/docs/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/docs/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
+</head>
+
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/docs/how-to-guides/vs-code-docker.md
+++ b/docs/how-to-guides/vs-code-docker.md
@@ -2,6 +2,10 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
+</head>
+
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/docs/how-to-guides/vs-code-remote-containers.md
+++ b/docs/how-to-guides/vs-code-remote-containers.md
@@ -2,6 +2,10 @@
 title: VS Code Remote Containers
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
+</head>
+
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/docs/references/architecture.md
+++ b/docs/references/architecture.md
@@ -2,6 +2,10 @@
 title: Architecture
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
+</head>
+
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.6/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.6/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
+</head>
+
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.6/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.6/how-to-guides/vs-code-docker.md
@@ -2,6 +2,10 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
+</head>
+
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.6/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.6/how-to-guides/vs-code-remote-containers.md
@@ -2,6 +2,10 @@
 title: VS Code Remote Containers
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
+</head>
+
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.6/references/architecture.md
+++ b/versioned_docs/version-1.6/references/architecture.md
@@ -2,6 +2,10 @@
 title: Architecture
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
+</head>
+
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.7/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.7/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
+</head>
+
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.7/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.7/how-to-guides/vs-code-docker.md
@@ -2,6 +2,10 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
+</head>
+
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.7/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.7/how-to-guides/vs-code-remote-containers.md
@@ -2,6 +2,10 @@
 title: VS Code Remote Containers
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
+</head>
+
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.7/references/architecture.md
+++ b/versioned_docs/version-1.7/references/architecture.md
@@ -2,6 +2,10 @@
 title: Architecture
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
+</head>
+
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.8/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.8/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
+</head>
+
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.8/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.8/how-to-guides/vs-code-docker.md
@@ -2,6 +2,10 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
+</head>
+
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.8/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.8/how-to-guides/vs-code-remote-containers.md
@@ -2,6 +2,10 @@
 title: VS Code Remote Containers
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
+</head>
+
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.8/references/architecture.md
+++ b/versioned_docs/version-1.8/references/architecture.md
@@ -2,6 +2,10 @@
 title: Architecture
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
+</head>
+
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.9/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.9/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,6 +5,10 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
+</head>
+
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.9/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.9/how-to-guides/vs-code-docker.md
@@ -2,6 +2,10 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
+</head>
+
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.9/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.9/how-to-guides/vs-code-remote-containers.md
@@ -2,6 +2,10 @@
 title: VS Code Remote Containers
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
+</head>
+
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.9/references/architecture.md
+++ b/versioned_docs/version-1.9/references/architecture.md
@@ -2,6 +2,10 @@
 title: Architecture
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
+</head>
+
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.


### PR DESCRIPTION
Adding canonical links to the final pages of the how-to section and the architecture page in the references section.