### PR TITLE
Update src/theme Global Import List

### DIFF
--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -2,13 +2,11 @@
 title: Deployment Profiles
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -7,6 +7,8 @@ slug: /
   <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
 </head>
 
+import TabsConstants from '@site/core/TabsConstants';
+
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
 </head>

--- a/docs/how-to-guides/create-multi-node-cluster.md
+++ b/docs/how-to-guides/create-multi-node-cluster.md
@@ -2,9 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
 </head>

--- a/docs/how-to-guides/hello-world-example.md
+++ b/docs/how-to-guides/hello-world-example.md
@@ -2,9 +2,6 @@
 title: Hello World Example
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
 </head>

--- a/docs/how-to-guides/increasing-open-file-limit.md
+++ b/docs/how-to-guides/increasing-open-file-limit.md
@@ -2,13 +2,11 @@
 title: Increasing Open File Limit
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 

--- a/docs/how-to-guides/installing-uninstalling-extensions.md
+++ b/docs/how-to-guides/installing-uninstalling-extensions.md
@@ -2,13 +2,11 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.
 

--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -2,11 +2,11 @@
 title: Provisioning Scripts
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 

--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -2,8 +2,6 @@
 title: Provisioning Scripts
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/docs/how-to-guides/rancher-on-rancher-desktop.md
+++ b/docs/how-to-guides/rancher-on-rancher-desktop.md
@@ -6,10 +6,6 @@ title: Rancher on Rancher Desktop
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
 </head>
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/docs/how-to-guides/rancher-on-rancher-desktop.md
+++ b/docs/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,6 +2,10 @@
 title: Rancher on Rancher Desktop
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
+</head>
+
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/docs/how-to-guides/rancher-on-rancher-desktop.md
+++ b/docs/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,9 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/docs/how-to-guides/running-air-gapped.md
+++ b/docs/how-to-guides/running-air-gapped.md
@@ -2,8 +2,6 @@
 title: Running When Offline
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/docs/how-to-guides/running-air-gapped.md
+++ b/docs/how-to-guides/running-air-gapped.md
@@ -2,11 +2,11 @@
 title: Running When Offline
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.

--- a/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,9 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -6,10 +6,6 @@ title: Setup NGINX Ingress Controller
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
 </head>
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,6 +2,10 @@
 title: Setup NGINX Ingress Controller
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
+</head>
+
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/docs/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/docs/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,9 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/docs/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/docs/how-to-guides/skaffold-and-rancher-desktop.md
@@ -6,10 +6,6 @@ title: Skaffold and Rancher Desktop
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
 </head>
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/docs/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/docs/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,6 +2,10 @@
 title: Skaffold and Rancher Desktop
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
+</head>
+
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/docs/how-to-guides/transfer-container-images.md
+++ b/docs/how-to-guides/transfer-container-images.md
@@ -2,9 +2,6 @@
 title: Transfer Container Images
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
 </head>

--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -2,9 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -6,10 +6,6 @@ title: "Command Reference: rdctl"
   <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
 </head>
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -2,6 +2,10 @@
 title: "Command Reference: rdctl"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
+</head>
+
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/docs/troubleshooting-tips.md
+++ b/docs/troubleshooting-tips.md
@@ -2,13 +2,11 @@
 title: Troubleshooting Tips
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 

--- a/docs/tutorials/working-with-containers.md
+++ b/docs/tutorials/working-with-containers.md
@@ -2,9 +2,6 @@
 title: Working with Containers
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
 </head>

--- a/docs/tutorials/working-with-images.md
+++ b/docs/tutorials/working-with-images.md
@@ -2,9 +2,6 @@
 title: Working with Images
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
 </head>

--- a/docs/ui/diagnostics.md
+++ b/docs/ui/diagnostics.md
@@ -3,11 +3,11 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.
 

--- a/docs/ui/diagnostics.md
+++ b/docs/ui/diagnostics.md
@@ -3,8 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/docs/ui/extensions.md
+++ b/docs/ui/extensions.md
@@ -3,11 +3,11 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog
 

--- a/docs/ui/extensions.md
+++ b/docs/ui/extensions.md
@@ -3,8 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/docs/ui/general.md
+++ b/docs/ui/general.md
@@ -3,11 +3,11 @@ sidebar_label: General
 title: General
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.
 

--- a/docs/ui/general.md
+++ b/docs/ui/general.md
@@ -3,8 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/docs/ui/images.md
+++ b/docs/ui/images.md
@@ -3,11 +3,11 @@ sidebar_label: Images
 title: Images
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 The **Images** tab, allows you to manage the images on your virtual machine.
 

--- a/docs/ui/images.md
+++ b/docs/ui/images.md
@@ -3,8 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Images** tab, allows you to manage the images on your virtual machine.

--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -3,8 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -3,11 +3,11 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">

--- a/docs/ui/preferences/application/behavior.md
+++ b/docs/ui/preferences/application/behavior.md
@@ -3,6 +3,10 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/docs/ui/preferences/application/behavior.md
+++ b/docs/ui/preferences/application/behavior.md
@@ -3,8 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/docs/ui/preferences/application/environment.md
+++ b/docs/ui/preferences/application/environment.md
@@ -3,6 +3,10 @@ sidebar_label: Environment
 title: Environment
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/docs/ui/preferences/application/environment.md
+++ b/docs/ui/preferences/application/environment.md
@@ -3,8 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/docs/ui/preferences/application/general.md
+++ b/docs/ui/preferences/application/general.md
@@ -3,6 +3,10 @@ sidebar_label: General
 title: General
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/docs/ui/preferences/application/general.md
+++ b/docs/ui/preferences/application/general.md
@@ -3,8 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/docs/ui/preferences/container-engine/allowed-images.md
+++ b/docs/ui/preferences/container-engine/allowed-images.md
@@ -3,8 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/docs/ui/preferences/container-engine/allowed-images.md
+++ b/docs/ui/preferences/container-engine/allowed-images.md
@@ -3,6 +3,10 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/docs/ui/preferences/container-engine/general.md
+++ b/docs/ui/preferences/container-engine/general.md
@@ -3,6 +3,10 @@ sidebar_label: General
 title: General
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/docs/ui/preferences/container-engine/general.md
+++ b/docs/ui/preferences/container-engine/general.md
@@ -3,8 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/docs/ui/preferences/kubernetes.md
+++ b/docs/ui/preferences/kubernetes.md
@@ -3,6 +3,10 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/preferences/kubernetes.md
+++ b/docs/ui/preferences/kubernetes.md
@@ -3,8 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/preferences/virtual-machine/emulation.md
+++ b/docs/ui/preferences/virtual-machine/emulation.md
@@ -3,6 +3,10 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
+</head>
+
  ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU

--- a/docs/ui/preferences/virtual-machine/hardware.md
+++ b/docs/ui/preferences/virtual-machine/hardware.md
@@ -3,6 +3,10 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/docs/ui/preferences/virtual-machine/hardware.md
+++ b/docs/ui/preferences/virtual-machine/hardware.md
@@ -3,8 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/docs/ui/preferences/virtual-machine/network.md
+++ b/docs/ui/preferences/virtual-machine/network.md
@@ -3,6 +3,10 @@ sidebar_label: Network
 title: Network (macOS)
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
+</head>
+
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable socket-vmnet

--- a/docs/ui/preferences/virtual-machine/volumes.md
+++ b/docs/ui/preferences/virtual-machine/volumes.md
@@ -3,8 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/docs/ui/preferences/virtual-machine/volumes.md
+++ b/docs/ui/preferences/virtual-machine/volumes.md
@@ -3,6 +3,10 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
+</head>
+
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -3,9 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabIntegrations.png)

--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -3,6 +3,10 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
+</head>
+
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabIntegrations.png)

--- a/docs/ui/preferences/wsl/network.md
+++ b/docs/ui/preferences/wsl/network.md
@@ -3,6 +3,10 @@ sidebar_label: Network
 title: Network (Windows)
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
+</head>
+
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel

--- a/docs/ui/preferences/wsl/proxy.md
+++ b/docs/ui/preferences/wsl/proxy.md
@@ -3,6 +3,10 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
+</head>
+
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/docs/ui/troubleshooting.md
+++ b/docs/ui/troubleshooting.md
@@ -3,8 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/troubleshooting.md
+++ b/docs/ui/troubleshooting.md
@@ -3,11 +3,11 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">

--- a/src/theme/MDXComponents/A.js
+++ b/src/theme/MDXComponents/A.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+export default function MDXA(props) {
+  return <Link {...props} />;
+}

--- a/src/theme/MDXComponents/Code.js
+++ b/src/theme/MDXComponents/Code.js
@@ -1,0 +1,42 @@
+import React, {isValidElement} from 'react';
+import CodeBlock from '@theme/CodeBlock';
+export default function MDXCode(props) {
+  const inlineElements = [
+    'a',
+    'abbr',
+    'b',
+    'br',
+    'button',
+    'cite',
+    'code',
+    'del',
+    'dfn',
+    'em',
+    'i',
+    'img',
+    'input',
+    'ins',
+    'kbd',
+    'label',
+    'object',
+    'output',
+    'q',
+    'ruby',
+    's',
+    'small',
+    'span',
+    'strong',
+    'sub',
+    'sup',
+    'time',
+    'u',
+    'var',
+    'wbr',
+  ];
+  const shouldBeInline = React.Children.toArray(props.children).every(
+    (el) =>
+      (typeof el === 'string' && !el.includes('\n')) ||
+      (isValidElement(el) && inlineElements.includes(el.props?.mdxType)),
+  );
+  return shouldBeInline ? <code {...props} /> : <CodeBlock {...props} />;
+}

--- a/src/theme/MDXComponents/Details.js
+++ b/src/theme/MDXComponents/Details.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Details from '@theme/Details';
+export default function MDXDetails(props) {
+  const items = React.Children.toArray(props.children);
+  // Split summary item from the rest to pass it as a separate prop to the
+  // Details theme component
+  const summary = items.find(
+    (item) => React.isValidElement(item) && item.props?.mdxType === 'summary',
+  );
+  const children = <>{items.filter((item) => item !== summary)}</>;
+  return (
+    <Details {...props} summary={summary}>
+      {children}
+    </Details>
+  );
+}

--- a/src/theme/MDXComponents/Head.js
+++ b/src/theme/MDXComponents/Head.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+// MDX elements are wrapped through the MDX pragma. In some cases (notably usage
+// with Head/Helmet) we need to unwrap those elements.
+function unwrapMDXElement(element) {
+  if (element.props?.mdxType && element.props.originalType) {
+    const {mdxType, originalType, ...newProps} = element.props;
+    return React.createElement(element.props.originalType, newProps);
+  }
+  return element;
+}
+export default function MDXHead(props) {
+  const unwrappedChildren = React.Children.map(props.children, (child) =>
+    React.isValidElement(child) ? unwrapMDXElement(child) : child,
+  );
+  return <Head {...props}>{unwrappedChildren}</Head>;
+}

--- a/src/theme/MDXComponents/Heading.js
+++ b/src/theme/MDXComponents/Heading.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import Heading from '@theme/Heading';
+export default function MDXHeading(props) {
+  return <Heading {...props} />;
+}

--- a/src/theme/MDXComponents/Pre.js
+++ b/src/theme/MDXComponents/Pre.js
@@ -1,0 +1,13 @@
+import React, {isValidElement} from 'react';
+import CodeBlock from '@theme/CodeBlock';
+export default function MDXPre(props) {
+  return (
+    <CodeBlock
+      // If this pre is created by a ``` fenced codeblock, unwrap the children
+      {...(isValidElement(props.children) &&
+      props.children.props?.originalType === 'code'
+        ? props.children.props
+        : {...props})}
+    />
+  );
+}

--- a/src/theme/MDXComponents/Ul/index.js
+++ b/src/theme/MDXComponents/Ul/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+function transformUlClassName(className) {
+  return clsx(
+    className,
+    // This class is set globally by GitHub/MDX. We keep the global class, and
+    // add another class to get a task list without the default ul styling
+    // See https://github.com/syntax-tree/mdast-util-to-hast/issues/28
+    className?.includes('contains-task-list') && styles.containsTaskList,
+  );
+}
+export default function MDXUl(props) {
+  return <ul {...props} className={transformUlClassName(props.className)} />;
+}

--- a/src/theme/MDXComponents/Ul/styles.module.css
+++ b/src/theme/MDXComponents/Ul/styles.module.css
@@ -1,0 +1,7 @@
+.containsTaskList {
+  list-style: none;
+}
+
+:not(.containsTaskList > li) > .containsTaskList {
+  padding-left: 0;
+}

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import MDXHead from '@theme/MDXComponents/Head';
+import MDXCode from '@theme/MDXComponents/Code';
+import MDXA from '@theme/MDXComponents/A';
+import MDXPre from '@theme/MDXComponents/Pre';
+import MDXDetails from '@theme/MDXComponents/Details';
+import MDXHeading from '@theme/MDXComponents/Heading';
+import MDXUl from '@theme/MDXComponents/Ul';
+import MDXImg from '@theme/MDXComponents/Img';
+import Admonition from '@theme/Admonition';
+import Mermaid from '@theme/Mermaid';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+const MDXComponents = {
+  head: MDXHead,
+  code: MDXCode,
+  a: MDXA,
+  pre: MDXPre,
+  details: MDXDetails,
+  ul: MDXUl,
+  img: MDXImg,
+  h1: (props) => <MDXHeading as="h1" {...props} />,
+  h2: (props) => <MDXHeading as="h2" {...props} />,
+  h3: (props) => <MDXHeading as="h3" {...props} />,
+  h4: (props) => <MDXHeading as="h4" {...props} />,
+  h5: (props) => <MDXHeading as="h5" {...props} />,
+  h6: (props) => <MDXHeading as="h6" {...props} />,
+  admonition: Admonition,
+  Tabs,
+  TabItem,
+  mermaid: Mermaid,
+};
+export default MDXComponents;


### PR DESCRIPTION
Swizzling `MDXComponents` under `src/theme` in order to add `Tabs` and `TabItem` to global import list.

This standardizes document files overall with respect to the header section. The changes made are the ejected markdown components being added under `src/theme` and the removal of `Tab` and `TabItem` from the `next` version. This follows the documentation structure in `elemental` files as well.

Additionally, this PR reformats the header section due to the import list change, and fixes canonical link merge conflicts.