### PR TITLE
Updating Provisioning Page - K3s example

### DIFF
--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -13,6 +13,7 @@ import TabsConstants from '@site/core/TabsConstants';
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux
+
 On macOS and Linux, you can use lima override.yaml to write provisioning scripts. 
 
 - Create `override.yaml` file at below path
@@ -46,14 +47,24 @@ provision:
     * hard     nofile         82920
     EOF
 ```
+
 - You can also use `override.yaml` to override/modify a lima configuration setting, for example, to create additional mounts as shown below.
+
 ```
 mounts:
   - location: /some/path 
     writable: true
 ```
 
-## Windows 
+- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax as seen below.
+
+```
+env:
+  K3S_EXEC: --tls-san x.x.x.x
+```
+
+## Windows
+
 **Caution:** You can only utilize these provisioning scripts for Rancher Desktop, version 1.1.0 or later, on Windows.
 
 - Run Rancher Desktop at least once to allow it to create its configuration.

--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -54,11 +54,11 @@ mounts:
     writable: true
 ```
 
-- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax as seen below.
+- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax (Similar to the `K3s` syntax [`INSTALL_K3S_EXEC`](https://docs.k3s.io/reference/env-variables#:~:text=as%20the%20default.-,INSTALL_K3S_EXEC,-Command%20with%20flags)). Please see the [agent](https://docs.k3s.io/cli/agent) and [server](https://docs.k3s.io/cli/server) command line flags documentation for further installation options. Below is an example setting using the [`--tls-san value`](https://docs.k3s.io/cli/server#:~:text=of%20the%20cluster-,%2D%2Dtls%2Dsan%20value,-N/A) flag to add additional hostnames as Subject Alternative Names on the TLS certification:
 
 ```
 env:
-  K3S_EXEC: --tls-san x.x.x.x
+  K3S_EXEC: --tls-san value
 ```
 
 ## Windows

--- a/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
@@ -13,6 +13,7 @@ import TabsConstants from '@site/core/TabsConstants';
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux
+
 On macOS and Linux, you can use lima override.yaml to write provisioning scripts. 
 
 - Create `override.yaml` file at below path
@@ -46,14 +47,24 @@ provision:
     * hard     nofile         82920
     EOF
 ```
+
 - You can also use `override.yaml` to override/modify a lima configuration setting, for example, to create additional mounts as shown below.
+
 ```
 mounts:
   - location: /some/path 
     writable: true
 ```
 
-## Windows 
+- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax as seen below.
+
+```
+env:
+  K3S_EXEC: --tls-san x.x.x.x
+```
+
+## Windows
+
 **Caution:** You can only utilize these provisioning scripts for Rancher Desktop, version 1.1.0 or later, on Windows.
 
 - Run Rancher Desktop at least once to allow it to create its configuration.

--- a/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
@@ -2,13 +2,11 @@
 title: Provisioning Scripts
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
@@ -56,11 +54,11 @@ mounts:
     writable: true
 ```
 
-- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax as seen below.
+- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax (Similar to the `K3s` syntax [`INSTALL_K3S_EXEC`](https://docs.k3s.io/reference/env-variables#:~:text=as%20the%20default.-,INSTALL_K3S_EXEC,-Command%20with%20flags)). Please see the [agent](https://docs.k3s.io/cli/agent) and [server](https://docs.k3s.io/cli/server) command line flags documentation for further installation options. Below is an example setting using the [`--tls-san value`](https://docs.k3s.io/cli/server#:~:text=of%20the%20cluster-,%2D%2Dtls%2Dsan%20value,-N/A) flag to add additional hostnames as Subject Alternative Names on the TLS certification:
 
 ```
 env:
-  K3S_EXEC: --tls-san x.x.x.x
+  K3S_EXEC: --tls-san value
 ```
 
 ## Windows

--- a/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
@@ -2,13 +2,11 @@
 title: Provisioning Scripts
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TabsConstants from '@site/core/TabsConstants';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
 </head>
+
+import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
@@ -56,11 +54,11 @@ mounts:
     writable: true
 ```
 
-- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax as seen below.
+- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax (Similar to the `K3s` syntax [`INSTALL_K3S_EXEC`](https://docs.k3s.io/reference/env-variables#:~:text=as%20the%20default.-,INSTALL_K3S_EXEC,-Command%20with%20flags)). Please see the [agent](https://docs.k3s.io/cli/agent) and [server](https://docs.k3s.io/cli/server) command line flags documentation for further installation options. Below is an example setting using the [`--tls-san value`](https://docs.k3s.io/cli/server#:~:text=of%20the%20cluster-,%2D%2Dtls%2Dsan%20value,-N/A) flag to add additional hostnames as Subject Alternative Names on the TLS certification:
 
 ```
 env:
-  K3S_EXEC: --tls-san x.x.x.x
+  K3S_EXEC: --tls-san value
 ```
 
 ## Windows

--- a/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
@@ -6,9 +6,14 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
+</head>
+
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux
+
 On macOS and Linux, you can use lima override.yaml to write provisioning scripts. 
 
 - Create `override.yaml` file at below path
@@ -42,14 +47,24 @@ provision:
     * hard     nofile         82920
     EOF
 ```
+
 - You can also use `override.yaml` to override/modify a lima configuration setting, for example, to create additional mounts as shown below.
+
 ```
 mounts:
   - location: /some/path 
     writable: true
 ```
 
-## Windows 
+- Another example uses the `override.yaml` file to allow users to implement custom settings for [`K3s`](https://k3s.io/?ref=traefik.io) environments using Rancher Desktop's `K3S_EXEC` syntax as seen below.
+
+```
+env:
+  K3S_EXEC: --tls-san x.x.x.x
+```
+
+## Windows
+
 **Caution:** You can only utilize these provisioning scripts for Rancher Desktop, version 1.1.0 or later, on Windows.
 
 - Run Rancher Desktop at least once to allow it to create its configuration.


### PR DESCRIPTION
Updating provisioning script page with an example on using K3S_EXEC for implementing custom settings for K3s. Also some minor formatting updates. This fixes https://github.com/rancher-sandbox/docs.rancherdesktop.io/issues/239. Converting to draft as this depends on some changes in https://github.com/rancher-sandbox/docs.rancherdesktop.io/pull/253.