### PR TITLE
Updating Skaffold Guide

### DIFF
--- a/docs/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/docs/how-to-guides/skaffold-and-rancher-desktop.md
@@ -23,9 +23,22 @@ In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sam
 
     Per the [Skaffold docs](https://skaffold.dev/docs/pipeline-stages/init/#build-config-initialization),`skaffold init` walks through your project directory and looks for any build configuration files such as `Dockerfile`, `build.gradle/pom.xml`, `package.json`, `requirements.txt`, or `go.mod`. 
     
-    We will select `Dockerfile` and `package.json` in our example. This will generate the initial configuration file that you can modify as needed. When prompted, select `yes` to write your config to `skaffold.yaml`. 
+    We will select `Dockerfile` and `package.json` in our example. This will generate the initial configuration file that you can modify as needed. When prompted, select `yes` to write your config to `skaffold.yaml`.
 
 1. In your editor, review your `app.js` and `manifests.yaml` files. Note that in `manifests.yaml`, you will have a deployment config as well as a service config. It is only necessary to have 1 `replica` for testing purposes.
+
+    Additionally, users can set their workloads `imagePullPolicy` to `IfNotPresent` (in this example the update can be made to the `manifests.yaml` file) which will allow for Skaffold to build locally without pushing the image to the registry. Users will need to update their `skaffold.yaml` as well in order to implement this change as noted below:
+
+    ```
+    apiVersion: skaffold/v2beta29
+    kind: Config
+    metadata:
+      name: skaffold
+    build:
+      local:
+        push: false
+        useDockerCLI: true
+    ```
 
 1. Back in your terminal, you'll notice that you will have two options: `skaffold run` that lets you build and deploy, and `skaffold dev` that allows you to enter development mode with auto-redeploy. We will use `skaffold dev` in this example.
 

--- a/versioned_docs/version-1.9/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.9/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,9 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
 </head>
@@ -26,9 +23,22 @@ In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sam
 
     Per the [Skaffold docs](https://skaffold.dev/docs/pipeline-stages/init/#build-config-initialization),`skaffold init` walks through your project directory and looks for any build configuration files such as `Dockerfile`, `build.gradle/pom.xml`, `package.json`, `requirements.txt`, or `go.mod`. 
     
-    We will select `Dockerfile` and `package.json` in our example. This will generate the initial configuration file that you can modify as needed. When prompted, select `yes` to write your config to `skaffold.yaml`. 
+    We will select `Dockerfile` and `package.json` in our example. This will generate the initial configuration file that you can modify as needed. When prompted, select `yes` to write your config to `skaffold.yaml`.
 
 1. In your editor, review your `app.js` and `manifests.yaml` files. Note that in `manifests.yaml`, you will have a deployment config as well as a service config. It is only necessary to have 1 `replica` for testing purposes.
+
+    Additionally, users can set their workloads `imagePullPolicy` to `IfNotPresent` (in this example the update can be made to the `manifests.yaml` file) which will allow for Skaffold to build locally without pushing the image to the registry. Users will need to update their `skaffold.yaml` as well in order to implement this change as noted below:
+
+    ```
+    apiVersion: skaffold/v2beta29
+    kind: Config
+    metadata:
+      name: skaffold
+    build:
+      local:
+        push: false
+        useDockerCLI: true
+    ```
 
 1. Back in your terminal, you'll notice that you will have two options: `skaffold run` that lets you build and deploy, and `skaffold dev` that allows you to enter development mode with auto-redeploy. We will use `skaffold dev` in this example.
 

--- a/versioned_docs/version-latest/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-latest/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,8 +2,9 @@
 title: Skaffold and Rancher Desktop
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
+</head>
 
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
@@ -22,9 +23,22 @@ In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sam
 
     Per the [Skaffold docs](https://skaffold.dev/docs/pipeline-stages/init/#build-config-initialization),`skaffold init` walks through your project directory and looks for any build configuration files such as `Dockerfile`, `build.gradle/pom.xml`, `package.json`, `requirements.txt`, or `go.mod`. 
     
-    We will select `Dockerfile` and `package.json` in our example. This will generate the initial configuration file that you can modify as needed. When prompted, select `yes` to write your config to `skaffold.yaml`. 
+    We will select `Dockerfile` and `package.json` in our example. This will generate the initial configuration file that you can modify as needed. When prompted, select `yes` to write your config to `skaffold.yaml`.
 
 1. In your editor, review your `app.js` and `manifests.yaml` files. Note that in `manifests.yaml`, you will have a deployment config as well as a service config. It is only necessary to have 1 `replica` for testing purposes.
+
+    Additionally, users can set their workloads `imagePullPolicy` to `IfNotPresent` (in this example the update can be made to the `manifests.yaml` file) which will allow for Skaffold to build locally without pushing the image to the registry. Users will need to update their `skaffold.yaml` as well in order to implement this change as noted below:
+
+    ```
+    apiVersion: skaffold/v2beta29
+    kind: Config
+    metadata:
+      name: skaffold
+    build:
+      local:
+        push: false
+        useDockerCLI: true
+    ```
 
 1. Back in your terminal, you'll notice that you will have two options: `skaffold run` that lets you build and deploy, and `skaffold dev` that allows you to enter development mode with auto-redeploy. We will use `skaffold dev` in this example.
 


### PR DESCRIPTION
Updating the Skaffold how-to to include information on how to build locally without pushing image to the registry.