### PR TITLE
Update Extensions | Installed with Remove

### DIFF
--- a/docs/how-to-guides/installing-uninstalling-extensions.md
+++ b/docs/how-to-guides/installing-uninstalling-extensions.md
@@ -109,7 +109,7 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -143,7 +143,7 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -177,7 +177,7 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/docs/how-to-guides/installing-uninstalling-extensions.md
+++ b/docs/how-to-guides/installing-uninstalling-extensions.md
@@ -99,9 +99,20 @@ Additionally, there are two ways in which you can uninstall extensions, a method
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Remove** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 
@@ -122,9 +133,20 @@ rdctl extension uninstall <image-id>:<tag>
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Remove** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 
@@ -145,9 +167,20 @@ rdctl extension uninstall <image-id>:<tag>
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Remove** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 

--- a/docs/ui/extensions.md
+++ b/docs/ui/extensions.md
@@ -59,4 +59,4 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 
 #### Name
 
-A list of names of installed extensions. Users can directly uninstall extensions by clicking the **Uninstall** button for the respective extension on the right hand side.
+A list of names of installed extensions. Users can directly uninstall extensions by clicking the **Remove** button for the respective extension on the right hand side.

--- a/versioned_docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.
 
 ### Prerequisites
@@ -101,9 +97,20 @@ Additionally, there are two ways in which you can uninstall extensions, a method
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Uninstall** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 
@@ -124,9 +131,20 @@ rdctl extension uninstall <image-id>:<tag>
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Uninstall** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 
@@ -147,9 +165,20 @@ rdctl extension uninstall <image-id>:<tag>
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Uninstall** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 

--- a/versioned_docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
@@ -97,9 +97,20 @@ Additionally, there are two ways in which you can uninstall extensions, a method
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Uninstall** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 
@@ -120,9 +131,20 @@ rdctl extension uninstall <image-id>:<tag>
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Uninstall** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 
@@ -143,9 +165,20 @@ rdctl extension uninstall <image-id>:<tag>
 
 #### Using the UI
 
-Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions.
+Click **Extensions** from the main UI to navigate to the **Catalog** tab. On this view, you can search through the available extensions, and uninstall the already installed extensions. Extensions can also be uninstalled from the **Installed** tab by clicking the **Uninstall** button.
+
+<Tabs>
+<TabItem value="Catalog">
 
 ![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+
+</TabItem>
+<TabItem value="Installed">
+
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+
+</TabItem>
+</Tabs>
 
 #### Using the Command Line
 


### PR DESCRIPTION
This updates the Extensions | Installed tab with the `Remove` button to uninstall extensions in place of `Uninstall`. This is tied to the work in https://github.com/rancher-sandbox/rancher-desktop/issues/5069. 

The `Extensions-Installed` images will be updated in a subsequent PR for the UI/Guides sections, and  additionally updated the how-to guides across versions showing the Installed tab and appropriate `Remove` or `Uninstall` button.