### PR TITLE
Updating the VM | Volumes (macOS & Linux) Page - virtiofs

### DIFF
--- a/docs/ui/preferences/virtual-machine/volumes.md
+++ b/docs/ui/preferences/virtual-machine/volumes.md
@@ -11,6 +11,8 @@ import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type
 
+### reverse-sshfs
+
 <Tabs groupId="os">
 <TabItem value="macOS">
 
@@ -24,9 +26,9 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 </Tabs>
 
-### reverse-sshfs
+Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/master/docs/mount.md#reverse-sshfs)" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then intitiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
 
-Users can enable the "reverse-sshfs" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then intitiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
+### 9p
 
 <Tabs groupId="os">
 <TabItem value="macOS">
@@ -40,8 +42,6 @@ Users can enable the "reverse-sshfs" mount type from the `Volumes` tab. This exp
 
 </TabItem>
 </Tabs>
-
-### 9p
 
 :::caution warning
 
@@ -63,15 +63,20 @@ Users can select the "9p" protocol version. The options include `[9p2000, 9p2000
 * Security Model:
 Users can select a supported security model with options being `[passthrough, mapped-xattr, mapped-file, none]`. The default security setting value is `none`.
 
+### virtiofs
+
 <Tabs groupId="os">
 <TabItem value="macOS">
 
 ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
-</Tabs>
+<TabItem value="Linux">
 
-### virtiofs
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
+
+</TabItem>
+</Tabs>
 
 :::caution warning
 

--- a/versioned_docs/version-1.9/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.9/ui/preferences/virtual-machine/volumes.md
@@ -9,6 +9,8 @@ import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type
 
+### reverse-sshfs
+
 <Tabs groupId="os">
 <TabItem value="macOS">
 
@@ -22,9 +24,9 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 </Tabs>
 
-### reverse-sshfs
+Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/master/docs/mount.md#reverse-sshfs)" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then intitiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
 
-Users can enable the "reverse-sshfs" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then intitiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
+### 9p
 
 <Tabs groupId="os">
 <TabItem value="macOS">
@@ -38,8 +40,6 @@ Users can enable the "reverse-sshfs" mount type from the `Volumes` tab. This exp
 
 </TabItem>
 </Tabs>
-
-### 9p
 
 :::caution warning
 
@@ -61,6 +61,8 @@ Users can select the "9p" protocol version. The options include `[9p2000, 9p2000
 * Security Model:
 Users can select a supported security model with options being `[passthrough, mapped-xattr, mapped-file, none]`. The default security setting value is `none`.
 
+### virtiofs
+
 <Tabs groupId="os">
 <TabItem value="macOS">
 
@@ -68,8 +70,6 @@ Users can select a supported security model with options being `[passthrough, ma
 
 </TabItem>
 </Tabs>
-
-### virtiofs
 
 :::caution warning
 

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
@@ -9,6 +9,8 @@ import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type
 
+### reverse-sshfs
+
 <Tabs groupId="os">
 <TabItem value="macOS">
 
@@ -22,9 +24,9 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 </Tabs>
 
-### reverse-sshfs
+Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/master/docs/mount.md#reverse-sshfs)" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then intitiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
 
-Users can enable the "reverse-sshfs" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then intitiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
+### 9p
 
 <Tabs groupId="os">
 <TabItem value="macOS">
@@ -38,8 +40,6 @@ Users can enable the "reverse-sshfs" mount type from the `Volumes` tab. This exp
 
 </TabItem>
 </Tabs>
-
-### 9p
 
 :::caution warning
 
@@ -61,6 +61,8 @@ Users can select the "9p" protocol version. The options include `[9p2000, 9p2000
 * Security Model:
 Users can select a supported security model with options being `[passthrough, mapped-xattr, mapped-file, none]`. The default security setting value is `none`.
 
+### virtiofs
+
 <Tabs groupId="os">
 <TabItem value="macOS">
 
@@ -68,8 +70,6 @@ Users can select a supported security model with options being `[passthrough, ma
 
 </TabItem>
 </Tabs>
-
-### virtiofs
 
 :::caution warning
 


### PR DESCRIPTION
Updating the VM | Volumes (macOS & Linux) page for 1.10 virtiofs addition to Linux, as well as changes to latest/1.9 formatting and definition link for reverse-sshfs. The image update will happen in a subsequent S3 update, but inputting the future image link URL in this PR. This is tied to https://github.com/rancher-sandbox/rancher-desktop/issues/5110.