### PR TITLE
Updating rdctl list-settings with correct output

### DIFF
--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -266,13 +266,7 @@ Run `rdctl list-settings` to see the current active configuration.
 
 ```autoupdate=true
 > rdctl list-settings --help 
-Lists the current settings in JSON or Windows registry-file format.
-The default output format is JSON.
-To convert the current settings into a registry file, run the following command:
-rdctl list-commands --output reg --reg-hive=X --profile=Y
-where X is either "hkcu" or "hklm", depending on whether you want to update HKEY_LOCAL_MACHINE
-or HKEY_CURRENT_USER respectively (default: "hklm"),
-and Y is either "defaults" or "locked", depending on which deployment profile you want to populate (default: "defaults").
+Lists the current settings in JSON format.
 
 Usage:
   rdctl list-settings [flags]


### PR DESCRIPTION
Updating the list-settings --help with the correct output and reverting `--output` update.