### PR TITLE
WSL Proxy - No proxy hostname list Update

### DIFF
--- a/docs/ui/preferences/wsl/proxy.md
+++ b/docs/ui/preferences/wsl/proxy.md
@@ -26,3 +26,7 @@ Users can input their proxy IP address and port number in the `Proxy address` fi
 ### Authentication information
 
 If your proxy requires authentication then users can input their username and password in the `Authentication information` fields.
+
+### No proxy hostname list
+
+Default hostnames that should not be proxied will be displayed in this text area.


### PR DESCRIPTION
Updating the proxy page with new field No proxy hostname list. This is tied to https://github.com/rancher-sandbox/rancher-desktop/issues/5100.