### PR TITLE
Linux Install Note - Tray Icon

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -140,6 +140,9 @@ It is also recommended to have:
 
 Additional resources may be required depending on the workloads you plan to run.
 
+:::note
+Some Linux distributions such as Ubuntu and Fedora that make use of Gnome do not support a system tray out of the box, and therefore no tray icon will be displayed for Rancher Desktop in these environments.
+:::
 
 #### Ensuring You Have Access to `/dev/kvm`
 

--- a/versioned_docs/version-1.10/getting-started/installation.md
+++ b/versioned_docs/version-1.10/getting-started/installation.md
@@ -140,6 +140,9 @@ It is also recommended to have:
 
 Additional resources may be required depending on the workloads you plan to run.
 
+:::note
+Some Linux distributions such as Ubuntu and Fedora that make use of Gnome do not support a system tray out of the box, and therefore no tray icon will be displayed for Rancher Desktop in these environments.
+:::
 
 #### Ensuring You Have Access to `/dev/kvm`
 

--- a/versioned_docs/version-latest/getting-started/installation.md
+++ b/versioned_docs/version-latest/getting-started/installation.md
@@ -140,6 +140,9 @@ It is also recommended to have:
 
 Additional resources may be required depending on the workloads you plan to run.
 
+:::note
+Some Linux distributions such as Ubuntu and Fedora that make use of Gnome do not support a system tray out of the box, and therefore no tray icon will be displayed for Rancher Desktop in these environments.
+:::
 
 #### Ensuring You Have Access to `/dev/kvm`
 


### PR DESCRIPTION
Updating install page Linux section with note on system tray being unavailable for certain distros, leading to RD's tray icon not being displayed. This is tied to #275.