### PR TITLE
Update environment.md 

### DIFF
--- a/versioned_docs/version-1.9/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.9/ui/preferences/application/environment.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Environment
-title: Environment(macOS & Linux)
+title: Environment (macOS & Linux)
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
After i install rancher desktop 1.9 in win 11, i can not find the environment under application tab, so i suppose this only shows in Mac or Linux os?
![image](https://github.com/rancher-sandbox/docs.rancherdesktop.io/assets/13114985/9d0ba9f2-0cd2-4005-bb41-7a33f0f5a390)
