### PR TITLE
Fixing Broken Links - Port Forwarding

### DIFF
--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -42,6 +42,6 @@ Rancher Desktop includes automated port forwarding for versions `1.9` and later.
 
 :::note
 
-Please see [Traefik Port Binding Access](../getting-started/installation#traefik-port-binding-access) to configure ports at the operating system level.
+Please see [Traefik Port Binding Access](https://docs.rancherdesktop.io/getting-started/installation/#traefik-port-binding-access) to configure ports at the operating system level.
 
 :::

--- a/versioned_docs/version-1.10/ui/port-forwarding.md
+++ b/versioned_docs/version-1.10/ui/port-forwarding.md
@@ -42,6 +42,6 @@ Rancher Desktop includes automated port forwarding for versions `1.9` and later.
 
 :::note
 
-Please see [Traefik Port Binding Access](../getting-started/installation#traefik-port-binding-access) to configure ports at the operating system level.
+Please see [Traefik Port Binding Access](https://docs.rancherdesktop.io/getting-started/installation/#traefik-port-binding-access) to configure ports at the operating system level.
 
 :::

--- a/versioned_docs/version-1.9/ui/port-forwarding.md
+++ b/versioned_docs/version-1.9/ui/port-forwarding.md
@@ -44,6 +44,6 @@ Rancher Desktop includes automated port forwarding for versions `1.9` and later.
 
 :::note
 
-Please see [Traefik Port Binding Access](../getting-started/installation#traefik-port-binding-access) to configure ports at the operating system level.
+Please see [Traefik Port Binding Access](https://docs.rancherdesktop.io/getting-started/installation/#traefik-port-binding-access) to configure ports at the operating system level.
 
 :::

--- a/versioned_docs/version-latest/ui/port-forwarding.md
+++ b/versioned_docs/version-latest/ui/port-forwarding.md
@@ -42,6 +42,6 @@ Rancher Desktop includes automated port forwarding for versions `1.9` and later.
 
 :::note
 
-Please see [Traefik Port Binding Access](../getting-started/installation#traefik-port-binding-access) to configure ports at the operating system level.
+Please see [Traefik Port Binding Access](https://docs.rancherdesktop.io/getting-started/installation/#traefik-port-binding-access) to configure ports at the operating system level.
 
 :::


### PR DESCRIPTION
Fixing broken links for Traefik Port Binding Access on the Port Forwarding page. Also reviewed links for next and latest versions and did not find any other broken links. This fixes #288 .