### PR TITLE
How-to Guide - Using Testcontainers

### DIFF
--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -37,12 +37,12 @@ You can download a sample test repository in the `testcontainers-java-repro` loc
 
 Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
 
-#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu)
+#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu.md)
 
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 
@@ -52,12 +52,12 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 
 </details>
 
-#### [VZ](../ui/preferences/virtual-machine/emulation#vz)
+#### [VZ](../ui/preferences/virtual-machine/emulation#vz.md)
 
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -42,7 +42,7 @@ Currently, workarounds are needed for using Testcontainers on macOS M1 machines.
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](https://docs.rancherdesktop.io/ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 
@@ -57,7 +57,7 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](https://docs.rancherdesktop.io/ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -37,7 +37,7 @@ You can download a sample test repository in the `testcontainers-java-repro` loc
 
 Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
 
-#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu.md)
+#### [QEMU](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#qemu)
 
 <details>
 <summary>Workaround Summary</summary>
@@ -52,7 +52,7 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 
 </details>
 
-#### [VZ](../ui/preferences/virtual-machine/emulation#vz.md)
+#### [VZ](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#vz)
 
 <details>
 <summary>Workaround Summary</summary>

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -1,0 +1,114 @@
+---
+title: Using Testcontainers on Rancher Desktop
+---
+
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
+</head>
+
+import TabsConstants from '@site/core/TabsConstants';
+
+Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.
+
+### Prerequisites
+
+[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled (which can be accomplished via the **Preferences > Kubernetes** dialog) for machines on Apple Silicon. Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+
+<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<TabItem value="Linux">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```bash
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+<TabItem value="macOS">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+<Tabs groupId="os">
+<TabItem value="Apple Silicon">
+
+Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
+
+#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu)
+
+<details>
+<summary>Workaround Summary</summary>
+
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+
+Next, export the virtual machine port explicitly using the command below:
+
+```bash
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+</details>
+
+#### [VZ](../ui/preferences/virtual-machine/emulation#vz)
+
+<details>
+<summary>Workaround Summary</summary>
+
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+
+Next, export the virtual machine port explicitly using the command below:
+
+```bash
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+For `VZ` virtual machines, you can also use Testcontainers without the need for administrative access by exporting the settings below:
+
+```bash
+export DOCKER_HOST=unix://$HOME/.rd/docker.sock
+export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+</details>
+
+After the respective virtual machine settings have been applied, and the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+<TabItem value="Intel">
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="Windows">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+</Tabs>

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -12,7 +12,13 @@ Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) t
 
 ### Prerequisites
 
-[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled (which can be accomplished via the **Preferences > Kubernetes** dialog) for machines on Apple Silicon. Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled for machines on Apple Silicon. The setting can be disabled via the **Preferences > Kubernetes** dialog, or by using the `rdctl` command below:
+
+```bash
+rdctl set --kubernetes-enabled=false
+```
+
+ Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">

--- a/sidebars.js
+++ b/sidebars.js
@@ -109,7 +109,8 @@ const sidebars = {
         "how-to-guides/increasing-open-file-limit",
         "how-to-guides/running-air-gapped",
         "how-to-guides/odo-rancher-desktop",
-        "how-to-guides/traefik-ingress-example"
+        "how-to-guides/traefik-ingress-example",
+        "how-to-guides/using-testcontainers"
       ],
     },
     {

--- a/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
@@ -37,12 +37,12 @@ You can download a sample test repository in the `testcontainers-java-repro` loc
 
 Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
 
-#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu)
+#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu.md)
 
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 
@@ -52,12 +52,12 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 
 </details>
 
-#### [VZ](../ui/preferences/virtual-machine/emulation#vz)
+#### [VZ](../ui/preferences/virtual-machine/emulation#vz.md)
 
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 

--- a/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
@@ -37,7 +37,7 @@ You can download a sample test repository in the `testcontainers-java-repro` loc
 
 Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
 
-#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu.md)
+#### [QEMU](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#qemu)
 
 <details>
 <summary>Workaround Summary</summary>
@@ -52,7 +52,7 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 
 </details>
 
-#### [VZ](../ui/preferences/virtual-machine/emulation#vz.md)
+#### [VZ](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#qemu)
 
 <details>
 <summary>Workaround Summary</summary>

--- a/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
@@ -42,7 +42,7 @@ Currently, workarounds are needed for using Testcontainers on macOS M1 machines.
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](https://docs.rancherdesktop.io/ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 
@@ -52,12 +52,12 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 
 </details>
 
-#### [VZ](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#qemu)
+#### [VZ](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#vz)
 
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](https://docs.rancherdesktop.io/ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 

--- a/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
@@ -1,0 +1,114 @@
+---
+title: Using Testcontainers on Rancher Desktop
+---
+
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
+</head>
+
+import TabsConstants from '@site/core/TabsConstants';
+
+Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.
+
+### Prerequisites
+
+[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled (which can be accomplished via the **Preferences > Kubernetes** dialog) for machines on Apple Silicon. Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+
+<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<TabItem value="Linux">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```bash
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+<TabItem value="macOS">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+<Tabs groupId="os">
+<TabItem value="Apple Silicon">
+
+Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
+
+#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu)
+
+<details>
+<summary>Workaround Summary</summary>
+
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+
+Next, export the virtual machine port explicitly using the command below:
+
+```bash
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+</details>
+
+#### [VZ](../ui/preferences/virtual-machine/emulation#vz)
+
+<details>
+<summary>Workaround Summary</summary>
+
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+
+Next, export the virtual machine port explicitly using the command below:
+
+```bash
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+For `VZ` virtual machines, you can also use Testcontainers without the need for administrative access by exporting the settings below:
+
+```bash
+export DOCKER_HOST=unix://$HOME/.rd/docker.sock
+export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+</details>
+
+After the respective virtual machine settings have been applied, and the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+<TabItem value="Intel">
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="Windows">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+</Tabs>

--- a/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
@@ -12,7 +12,13 @@ Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) t
 
 ### Prerequisites
 
-[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled (which can be accomplished via the **Preferences > Kubernetes** dialog) for machines on Apple Silicon. Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled for machines on Apple Silicon. The setting can be disabled via the **Preferences > Kubernetes** dialog, or by using the `rdctl` command below:
+
+```bash
+rdctl set --kubernetes-enabled=false
+```
+
+ Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -37,12 +37,12 @@ You can download a sample test repository in the `testcontainers-java-repro` loc
 
 Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
 
-#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu)
+#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu.md)
 
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 
@@ -52,12 +52,12 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 
 </details>
 
-#### [VZ](../ui/preferences/virtual-machine/emulation#vz)
+#### [VZ](../ui/preferences/virtual-machine/emulation#vz.md)
 
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -42,7 +42,7 @@ Currently, workarounds are needed for using Testcontainers on macOS M1 machines.
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](https://docs.rancherdesktop.io/ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 
@@ -57,7 +57,7 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 <details>
 <summary>Workaround Summary</summary>
 
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](https://docs.rancherdesktop.io/ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
 
 Next, export the virtual machine port explicitly using the command below:
 

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -37,7 +37,7 @@ You can download a sample test repository in the `testcontainers-java-repro` loc
 
 Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
 
-#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu.md)
+#### [QEMU](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#qemu)
 
 <details>
 <summary>Workaround Summary</summary>
@@ -52,7 +52,7 @@ export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {
 
 </details>
 
-#### [VZ](../ui/preferences/virtual-machine/emulation#vz.md)
+#### [VZ](https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation#vz)
 
 <details>
 <summary>Workaround Summary</summary>

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -1,0 +1,114 @@
+---
+title: Using Testcontainers on Rancher Desktop
+---
+
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
+</head>
+
+import TabsConstants from '@site/core/TabsConstants';
+
+Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.
+
+### Prerequisites
+
+[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled (which can be accomplished via the **Preferences > Kubernetes** dialog) for machines on Apple Silicon. Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+
+<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<TabItem value="Linux">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```bash
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+<TabItem value="macOS">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+<Tabs groupId="os">
+<TabItem value="Apple Silicon">
+
+Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
+
+#### [QEMU](../ui/preferences/virtual-machine/emulation#qemu)
+
+<details>
+<summary>Workaround Summary</summary>
+
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+
+Next, export the virtual machine port explicitly using the command below:
+
+```bash
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+</details>
+
+#### [VZ](../ui/preferences/virtual-machine/emulation#vz)
+
+<details>
+<summary>Workaround Summary</summary>
+
+This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general) dialog. This will ensure that routable IP's are allocated.
+
+Next, export the virtual machine port explicitly using the command below:
+
+```bash
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+For `VZ` virtual machines, you can also use Testcontainers without the need for administrative access by exporting the settings below:
+
+```bash
+export DOCKER_HOST=unix://$HOME/.rd/docker.sock
+export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+```
+
+</details>
+
+After the respective virtual machine settings have been applied, and the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+<TabItem value="Intel">
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="Windows">
+
+You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+
+After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+
+```shell
+mvn verify
+```
+
+After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+
+</TabItem>
+</Tabs>

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -12,7 +12,13 @@ Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) t
 
 ### Prerequisites
 
-[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled (which can be accomplished via the **Preferences > Kubernetes** dialog) for machines on Apple Silicon. Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled for machines on Apple Silicon. The setting can be disabled via the **Preferences > Kubernetes** dialog, or by using the `rdctl` command below:
+
+```bash
+rdctl set --kubernetes-enabled=false
+```
+
+ Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">

--- a/versioned_sidebars/version-1.10-sidebars.json
+++ b/versioned_sidebars/version-1.10-sidebars.json
@@ -90,7 +90,8 @@
         "how-to-guides/increasing-open-file-limit",
         "how-to-guides/running-air-gapped",
         "how-to-guides/odo-rancher-desktop",
-        "how-to-guides/traefik-ingress-example"
+        "how-to-guides/traefik-ingress-example",
+        "how-to-guides/using-testcontainers"
       ]
     },
     {

--- a/versioned_sidebars/version-latest-sidebars.json
+++ b/versioned_sidebars/version-latest-sidebars.json
@@ -90,7 +90,8 @@
         "how-to-guides/increasing-open-file-limit",
         "how-to-guides/running-air-gapped",
         "how-to-guides/odo-rancher-desktop",
-        "how-to-guides/traefik-ingress-example"
+        "how-to-guides/traefik-ingress-example",
+        "how-to-guides/using-testcontainers"
       ]
     },
     {


### PR DESCRIPTION
Adding how-to guide for using Testcontainers on Rancher Desktop for Linux, macOS(workarounds for M1 machines included), and Windows. This fixes #282 .