### PR TITLE
How-to Mirror Private Registry

### DIFF
--- a/docs/how-to-guides/mirror-private-registry.md
+++ b/docs/how-to-guides/mirror-private-registry.md
@@ -15,6 +15,8 @@ Rancher Desktop can be configured to mirror private registries using either cont
 
 Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts) that can be used to mirror private registries.
 
+Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands:
+
 Override File Path:
 `$HOME/.local/share/rancher-desktop/lima/_config/override.yaml`
 
@@ -38,6 +40,8 @@ provision:
 <TabItem value="macOS">
 
 Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts) that can be used to mirror private registries.
+
+Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands:
 
 Override File Path:
 `$HOME/Library/Application Support/rancher-desktop/lima/_config/override.yaml`
@@ -68,7 +72,7 @@ wsl -d rancher-desktop mkdir -p /etc/rancher/k3s
 wsl -d rancher-desktop cp registries.yaml /etc/rancher/k3s
 ```
 
-Here is an example of the mirror private registries configuration in your `registries.yaml` file:
+Here is an example of the mirrored private registries configuration in your `registries.yaml` file:
 
 ```yaml
 mirrors:

--- a/docs/how-to-guides/mirror-private-registry.md
+++ b/docs/how-to-guides/mirror-private-registry.md
@@ -15,14 +15,14 @@ Rancher Desktop can be configured to mirror private registries using either cont
 
 Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts/#macos--linux) that can be used to mirror private registries.
 
-Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands:
+Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
 Override File Path:
 `$HOME/.local/share/rancher-desktop/lima/_config/override.yaml`
 
+Example Script:
 ```bash
 provision:
-...
   - mode: system
     script: |
       #!/bin/sh
@@ -47,14 +47,15 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 
 Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts/#macos--linux) that can be used to mirror private registries.
 
-Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands:
+Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
 Override File Path:
 `$HOME/Library/Application Support/rancher-desktop/lima/_config/override.yaml`
 
+Example Script:
+
 ```bash
 provision:
-...
   - mode: system
     script: |
       #!/bin/sh
@@ -81,13 +82,10 @@ Ensure that you have initialized the application with a first run in order to cr
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 
-File Path:
+`.start` File Path:
+`$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start`
 
-```shell
-$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start
-```
-
-Example `mirror-registry.start` file configuration:
+Example Script:
 
 ```shell
 #!/bin/sh

--- a/docs/how-to-guides/mirror-private-registry.md
+++ b/docs/how-to-guides/mirror-private-registry.md
@@ -13,7 +13,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts) that can be used to mirror private registries.
+Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts/#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands:
 
@@ -36,10 +36,16 @@ provision:
       EOF
 ```
 
+After restarting the applicaition, you can verify the script being applied using the `rdctl shell` command below:
+
+```bash
+rdctl shell -- cat /etc/rancher/k3s/registries.yaml
+```
+
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts) that can be used to mirror private registries.
+Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts/#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands:
 
@@ -62,23 +68,46 @@ provision:
       EOF
 ```
 
+After restarting the applicaition, you can verify the script being applied using the `rdctl shell` command below:
+
+```bash
+rdctl shell -- cat /etc/rancher/k3s/registries.yaml
+```
+
 </TabItem>
 <TabItem value="Windows">
 
-Check if you have the directory below that may have been created upon `k3s` spinning up. If not, create the directory and `registries.yaml` file using the powershell commands below:
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts/#windows) can be utilized to mirror private registries using a `.start` file.
+
+The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
+
+File Path:
 
 ```shell
-wsl -d rancher-desktop mkdir -p /etc/rancher/k3s
-wsl -d rancher-desktop cp registries.yaml /etc/rancher/k3s
+$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start
 ```
 
-Here is an example of the mirrored private registries configuration in your `registries.yaml` file:
+Example `mirror-registry.start` file configuration:
 
-```yaml
+```shell
+#!/bin/sh
+
+set -eux
+
+mkdir -p /etc/rancher/k3s
+
+cat <<EOF >/etc/rancher/k3s/registries.yaml
 mirrors:
-  "docker.io":
-    endpoint:
-      - https://<my-private-registry>:5000
+  "localhost:5000":
+  endpoint:
+    - http://localhost:5000
+EOF
+```
+
+Verify using the `rdctl shell` command below that the script is applied:
+
+```shell
+rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 ```
 
 </TabItem>

--- a/docs/how-to-guides/mirror-private-registry.md
+++ b/docs/how-to-guides/mirror-private-registry.md
@@ -1,0 +1,81 @@
+---
+title: Mirroring Private Registries
+---
+
+import TabsConstants from '@site/core/TabsConstants';
+
+<head>
+  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
+</head>
+
+Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
+
+<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
+<TabItem value="Linux">
+
+Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts) that can be used to mirror private registries.
+
+Override File Path:
+`$HOME/.local/share/rancher-desktop/lima/_config/override.yaml`
+
+```bash
+provision:
+...
+  - mode: system
+    script: |
+      #!/bin/sh
+      set -eux
+      mkdir -p /etc/rancher/k3s
+      cat <<EOF >/etc/rancher/k3s/registries.yaml
+      mirrors:
+        "<my.private.registry>:5000":
+          endpoint:
+          - http://<my.private.registry>:5000
+      EOF
+```
+
+</TabItem>
+<TabItem value="macOS">
+
+Below is an example [provisioning script](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts) that can be used to mirror private registries.
+
+Override File Path:
+`$HOME/Library/Application Support/rancher-desktop/lima/_config/override.yaml`
+
+```bash
+provision:
+...
+  - mode: system
+    script: |
+      #!/bin/sh
+      set -eux
+      mkdir -p /etc/rancher/k3s
+      cat <<EOF >/etc/rancher/k3s/registries.yaml
+      mirrors:
+        "<my.private.registry>:5000":
+          endpoint:
+          - http://<my.private.registry>:5000
+      EOF
+```
+
+</TabItem>
+<TabItem value="Windows">
+
+Check if you have the directory below that may have been created upon `k3s` spinning up. If not, create the directory and `registries.yaml` file using the powershell commands below:
+
+```shell
+wsl -d rancher-desktop mkdir -p /etc/rancher/k3s
+wsl -d rancher-desktop cp registries.yaml /etc/rancher/k3s
+```
+
+Here is an example of the mirror private registries configuration in your `registries.yaml` file:
+
+```yaml
+mirrors:
+  "docker.io":
+    endpoint:
+      - https://<my-private-registry>:5000
+```
+
+</TabItem>
+</Tabs>

--- a/sidebars.js
+++ b/sidebars.js
@@ -110,7 +110,8 @@ const sidebars = {
         "how-to-guides/running-air-gapped",
         "how-to-guides/odo-rancher-desktop",
         "how-to-guides/traefik-ingress-example",
-        "how-to-guides/using-testcontainers"
+        "how-to-guides/using-testcontainers",
+        "how-to-guides/mirror-private-registry"
       ],
     },
     {


### PR DESCRIPTION
Adding a how-to guide for mirroring private registries in Rancher Desktop via provisioning script or updating the registry file. This fixes #259.
