### PR TITLE
Remove WSL Workaround for 1.11

### DIFF
--- a/docs/ui/preferences/wsl/proxy.md
+++ b/docs/ui/preferences/wsl/proxy.md
@@ -30,15 +30,3 @@ If your proxy requires authentication then users can input their username and pa
 ### No proxy hostname list
 
 Default hostnames that should not be proxied will be displayed in this text area.
-
-### Known Issues
-
-There is a known issue with using Rancher Desktop and the `wsl-vpnkit` distribution for WSL. If the distro is installed, Rancher Desktop will be unable to run.
-
-As a workaround while this issue is being investigated, please uninstall the distribution in order to run Rancher Desktop. This can be achieved by the command below in a powershell terminal:
-
-```shell
-wsl --unregister wsl-vpnkit
-```
-
-Please see this [issue thread](https://github.com/rancher-sandbox/rancher-desktop/issues/4966) for further information.


### PR DESCRIPTION
The issue has been fixed for the upcoming 1.11 release, removing the workaround for the next version.