### PR TITLE
Traefik Guide - Update Windows $IP

### DIFF
--- a/docs/how-to-guides/traefik-ingress-example.md
+++ b/docs/how-to-guides/traefik-ingress-example.md
@@ -239,7 +239,7 @@ Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://
 1. Open a powershell session and set the node IP to your local address:
 
   ```shell
-  $IP = (kubectl get node/$env:COMPUTERNAME -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+  $IP = (kubectl get node/$env:COMPUTERNAME -o=jsonpath="{range .status.addresses[?(@.type == 'InternalIP')]}{.address}{end}")
   ```
 
 1. Create a namespace called demo:

--- a/versioned_docs/version-1.10/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.10/how-to-guides/traefik-ingress-example.md
@@ -239,7 +239,7 @@ Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://
 1. Open a powershell session and set the node IP to your local address:
 
   ```shell
-  $IP = (kubectl get node/$env:COMPUTERNAME -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+  $IP = (kubectl get node/$env:COMPUTERNAME -o=jsonpath="{range .status.addresses[?(@.type == 'InternalIP')]}{.address}{end}")
   ```
 
 1. Create a namespace called demo:

--- a/versioned_docs/version-latest/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-latest/how-to-guides/traefik-ingress-example.md
@@ -239,7 +239,7 @@ Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://
 1. Open a powershell session and set the node IP to your local address:
 
   ```shell
-  $IP = (kubectl get node/$env:COMPUTERNAME -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+  $IP = (kubectl get node/$env:COMPUTERNAME -o=jsonpath="{range .status.addresses[?(@.type == 'InternalIP')]}{.address}{end}")
   ```
 
 1. Create a namespace called demo:


### PR DESCRIPTION
Updating the Windows steps for the Traefik Guide on setting the `$IP` correctly after the current command has produced errors trying to implement the setting. This has been tested for Windows 10/11. Fixes #307 