### PR TITLE
Update kubeconfig WSL Behavior

### DIFF
--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -15,3 +15,13 @@ With WSL, memory and CPU allocation is configured globally across all Linux dist
 
 [WSL documentation]:
 https://docs.microsoft.com/en-us/windows/wsl/wsl-config#options-for-wslconfig
+
+:::caution warning
+Symlinks are unsupported for Rancher Desktop versions `<= 1.11.1` with WSL integration enabled.
+:::
+
+Rancher Desktop versions `<= 1.11.1` no longer supports a symlink from the `~/.kube/config` file to the instance on your Windows filesystem. This is due to the Kubernetes endpoint differing between the Windows host and inside a WSL2 distribution. The application will replace found symlinks with a separate file instead.
+
+If the file inside the distribution is a symlink to the default location on the host, then Rancher Desktop will delete it and create a new file with the cluster configuration that works from inside the distribution. If it is a separate file, or a symlink to any other location, then Rancher Desktop will update that file with the `rancher-desktop` context instead.
+
+Consequently, the "Kubernetes context" menu entry for the notification will show (and change) the context for the Win32 side only. The contexts inside distributions will need to be managed manually from a command prompt.

--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -16,12 +16,14 @@ With WSL, memory and CPU allocation is configured globally across all Linux dist
 [WSL documentation]:
 https://docs.microsoft.com/en-us/windows/wsl/wsl-config#options-for-wslconfig
 
-:::caution warning
-Symlinks are unsupported for Rancher Desktop versions `<= 1.11.1` with WSL integration enabled.
+:::caution warning: breaking change
+
 :::
 
-Rancher Desktop versions `<= 1.11.1` no longer supports a symlink from the `~/.kube/config` file to the instance on your Windows filesystem. This is due to the Kubernetes endpoint differing between the Windows host and inside a WSL2 distribution. The application will replace found symlinks with a separate file instead.
+Starting with version `1.11.1`, Rancher Desktop no longer supports a symlink from the `~/.kube/config` file to the instance on your Windows filesystem. This is due to the Kubernetes endpoint differing between the Windows host and inside a WSL2 distribution. The application will replace found symlinks with a separate file instead.
 
-If the file inside the distribution is a symlink to the default location on the host, then Rancher Desktop will delete it and create a new file with the cluster configuration that works from inside the distribution. If it is a separate file, or a symlink to any other location, then Rancher Desktop will update that file with the `rancher-desktop` context instead.
+If the file inside the distribution is a separate file, or a symlink to any other location, then Rancher Desktop will update that file with the `rancher-desktop` context.
+
+However, if the file is a symlink to the default location on the host, then Rancher Desktop will delete it and create a new file with the cluster configuration that works from inside the distribution.
 
 Consequently, the "Kubernetes context" menu entry for the notification will show (and change) the context for the Win32 side only. The contexts inside distributions will need to be managed manually from a command prompt.

--- a/docs/ui/preferences/wsl/network.md
+++ b/docs/ui/preferences/wsl/network.md
@@ -11,10 +11,4 @@ title: Network (Windows)
 
 ### Networking Tunnel
 
-:::caution warning
-
-This is an **experimental** setting.
-
-:::
-
-Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the experimental Rancher Desktop Network.
+Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the Rancher Desktop tunneling network.

--- a/docs/ui/preferences/wsl/network.md
+++ b/docs/ui/preferences/wsl/network.md
@@ -11,4 +11,10 @@ title: Network (Windows)
 
 ### Networking Tunnel
 
-Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the Rancher Desktop tunneling network.
+:::caution warning
+
+This is an **experimental** setting.
+
+:::
+
+Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the experimental Rancher Desktop Network.


### PR DESCRIPTION
Adding in a warning section for the WSL Integrations page on symlinks being unsupported for RD versions 1.11.1 and later. Also removing the experimental flag for the Windows Network as it will be the default network in the 1.12 release.

Fixes #322 