### PR TITLE
Add deployment version to all the samples

### DIFF
--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -38,6 +38,7 @@ The structure of the profile data matches the application settings:
 
 ```json title="rdctl list-settings"
 {
+  "version": 10,
   ...
   "containerEngine": {
     "allowedImages": {
@@ -116,6 +117,7 @@ reg delete "HKCU\Software\Policies\Rancher Desktop" /f
 #### By default use the "moby" container engine and disable Kubernetes
 
 ```
+reg add "HKCU\Software\Policies\Rancher Desktop\Defaults" /v version /t REG_DWORD -d 10
 reg add "HKCU\Software\Policies\Rancher Desktop\Defaults\containerEngine" /v name /t REG_SZ -d moby
 reg add "HKCU\Software\Policies\Rancher Desktop\Defaults\kubernetes" /v enabled /t REG_DWORD -d 0
 ```
@@ -123,6 +125,7 @@ reg add "HKCU\Software\Policies\Rancher Desktop\Defaults\kubernetes" /v enabled 
 #### Lock allowed images list to only allow "busybox" and "nginx"
 
 ```
+reg add "HKCU\Software\Policies\Rancher Desktop\Locked" /v version /t REG_DWORD -d 10
 reg add "HKCU\Software\Policies\Rancher Desktop\Locked\containerEngine\allowedImages" /v enabled /t REG_DWORD -d 1
 reg add "HKCU\Software\Policies\Rancher Desktop\Locked\containerEngine\allowedImages" /v patterns /t REG_MULTI_SZ -d busybox\0nginx
 ```
@@ -144,6 +147,7 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\Policies\Rancher Desktop]
 
 [HKEY_CURRENT_USER\Software\Policies\Rancher Desktop\Defaults]
+"version"=dword:a
 
 [HKEY_CURRENT_USER\Software\Policies\Rancher Desktop\Defaults\containerEngine]
 "name"="moby"
@@ -152,6 +156,7 @@ Windows Registry Editor Version 5.00
 "enabled"=dword:00000000
 
 [HKEY_CURRENT_USER\Software\Policies\Rancher Desktop\Locked]
+"version"=dword:a
 
 [HKEY_CURRENT_USER\Software\Policies\Rancher Desktop\Locked\containerEngine]
 
@@ -191,6 +196,8 @@ Alternatively the profile can be created manually, either with an editor, or wit
 DEFAULTS=~/Library/Preferences/io.rancherdesktop.profile.defaults.plist
 plutil -create xml1 "$DEFAULTS"
 
+plutil -insert version -integer 10 "$DEFAULTS"
+
 plutil -insert containerEngine -dictionary "$DEFAULTS"
 plutil -insert containerEngine.name -string moby "$DEFAULTS"
 
@@ -203,6 +210,8 @@ plutil -insert kubernetes.enabled -bool false "$DEFAULTS"
 ```
 LOCKED=~/Library/Preferences/io.rancherdesktop.profile.locked.plist
 plutil -create xml1 "$LOCKED"
+
+plutil -insert version -integer 10 "$LOCKED"
 
 plutil -insert containerEngine -dictionary "$LOCKED"
 plutil -insert containerEngine.allowedImages -dictionary "$LOCKED"
@@ -230,6 +239,8 @@ plutil -insert containerEngine.allowedImages.patterns -string nginx -append "$LO
 		<key>enabled</key>
 		<false/>
 	</dict>
+	<key>version</key>
+	<integer>10</integer>
 </dict>
 </plist>
 ```
@@ -252,6 +263,8 @@ plutil -insert containerEngine.allowedImages.patterns -string nginx -append "$LO
 			</array>
 		</dict>
 	</dict>
+	<key>version</key>
+	<integer>10</integer>
 </dict>
 </plist>
 ```
@@ -282,6 +295,7 @@ rdctl list-settings > ~/.config/rancher-desktop.defaults.json
 
 ```json title="~/.config/rancher-desktop.defaults.json"
 {
+  "version": 10,
   "containerEngine": {
     "name": "moby"
   },
@@ -295,6 +309,7 @@ rdctl list-settings > ~/.config/rancher-desktop.defaults.json
 
 ```json title="~/.config/rancher-desktop.locked.json"
 {
+  "version": 10,
   "containerEngine": {
     "allowedImages": {
       "enabled": true,
@@ -367,7 +382,11 @@ HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Rancher Desktop\Defaults
 HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Rancher Desktop\Locked
 ```
 
-Then add a `DWORD` value named `version`, with value `10` (hexadecimal a) at the top level of each profile that needs updating.
+Then add a `DWORD` value named `version`, with value `10` (hexadecimal `a`) at the top level of each profile that needs updating:
+
+```console
+"version"=dword:a
+```
 
 ### Known Issues and Limitations
 


### PR DESCRIPTION
It is required as of Rancher Desktop 1.12.0, so the samples no longer work without the version field.