### PR TITLE
Preferences: WSL: Network tunnel is no longer experimental

### DIFF
--- a/docs/ui/preferences/wsl/network.md
+++ b/docs/ui/preferences/wsl/network.md
@@ -11,10 +11,4 @@ title: Network (Windows)
 
 ### Networking Tunnel
 
-:::caution warning
-
-This is an **experimental** setting.
-
-:::
-
 Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the experimental Rancher Desktop Network.

--- a/versioned_docs/version-1.12/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/network.md
@@ -11,10 +11,4 @@ title: Network (Windows)
 
 ### Networking Tunnel
 
-:::caution warning
-
-This is an **experimental** setting.
-
-:::
-
 Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the experimental Rancher Desktop Network.

--- a/versioned_docs/version-latest/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/network.md
@@ -11,10 +11,4 @@ title: Network (Windows)
 
 ### Networking Tunnel
 
-:::caution warning
-
-This is an **experimental** setting.
-
-:::
-
 Users can enable or disable the networking tunnel from the `Network` view. After changes are applied, Kubernetes will be restarted. Please see [developer notes](https://github.com/rancher-sandbox/rancher-desktop-networking) for more information on the experimental Rancher Desktop Network.


### PR DESCRIPTION
On Windows, network tunnel is no longer experimental as of 1.12.

Reference: https://github.com/rancher-sandbox/rancher-desktop/pull/6136