### PR TITLE
Update deployment.md macOS "version" key lowercase

### DIFF
--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -364,7 +364,7 @@ System deployments are stored in:
 /Library/Preferences/io.rancherdesktop.profile.locked.plist
 ```
 
-Then add `<key>Version</key><integer>10</integer>` after the initial `<dict>` tag into your respective `.plist` file.
+Then add `<key>version</key><integer>10</integer>` after the initial `<dict>` tag into your respective `.plist` file.
 
 #### Windows
 


### PR DESCRIPTION
Capitalized "Version" key does not work, which is hinted at by #6296 (though not super-clear), as well as elsewhere in this document where lowercase version is used with the `plutil` commands.