### PR TITLE
Sync Deployment Page

### DIFF
--- a/versioned_docs/version-1.12/getting-started/deployment.md
+++ b/versioned_docs/version-1.12/getting-started/deployment.md
@@ -364,7 +364,7 @@ System deployments are stored in:
 /Library/Preferences/io.rancherdesktop.profile.locked.plist
 ```
 
-Then add `<key>Version</key><integer>10</integer>` after the initial `<dict>` tag into your respective `.plist` file.
+Then add `<key>version</key><integer>10</integer>` after the initial `<dict>` tag into your respective `.plist` file.
 
 #### Windows
 

--- a/versioned_docs/version-latest/getting-started/deployment.md
+++ b/versioned_docs/version-latest/getting-started/deployment.md
@@ -364,7 +364,7 @@ System deployments are stored in:
 /Library/Preferences/io.rancherdesktop.profile.locked.plist
 ```
 
-Then add `<key>Version</key><integer>10</integer>` after the initial `<dict>` tag into your respective `.plist` file.
+Then add `<key>version</key><integer>10</integer>` after the initial `<dict>` tag into your respective `.plist` file.
 
 #### Windows
 


### PR DESCRIPTION
Syncing the deployment page after update to the version key is applied.

Attached to https://github.com/rancher-sandbox/docs.rancherdesktop.io/pull/340