### PR TITLE
Expanded Wasm tutorial to cover steps from code to Wasm to containers

### DIFF
--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -82,7 +82,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 }
 ```
 
-Change to the app diretory and run the `spin build` command to compile the app code into a Wasm module.
+Change to the app directory and run the `spin build` command to compile the app code into a Wasm module.
 
 ```
 $spin build

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -51,7 +51,7 @@ Pick a template to start your application with:
 ```
 
 Give a name to your app
-```
+```console
 $spin new
 Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
 Enter a name for your new application: rd-spin-hello-world

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -103,7 +103,7 @@ Finished building all Spin components
 
 Once the build command ran successfully, you should see the `rd-spin-hello-world.wasm` module created inside the `target` directory.
 
-### Package the Wasm module as a OCI contianer image and push to a container registry
+### Package the Wasm Module as an OCI Container Image and Push to a Container Registry
 
 Create a `Dockerfile` with below code to package the `Wasm` module as a docker image.
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -26,7 +26,7 @@ For now additional shims can be installed by the user into the `containerd-shims
 
 Any shim installed there will automatically be copied into the VM and configured for the container engine when Rancher Desktop is started (installing a newer version of the `spin` shim will override the bundled version).
 
-## Developing Wasm applications with Rancher Desktop
+## Developing Wasm Applications with Rancher Desktop
 
 Developing Wasm applications on your local machine on top of Rancher Desktop typically involves below steps:
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -32,7 +32,7 @@ Developing Wasm applications on your local machine on top of Rancher Desktop typ
 
 - Create an application in your programming language of choice. You can compile code written in many languages, such as C, C++, Rust, Go, and others, into Wasm modules
 - Compile the code into a Wasm module
-- Package the Wasm module as a OCI contianer image and push to a container registry
+- Package the Wasm module as a OCI container image and push to a container registry
 - Run the Wasm container and/or
 - Deploy the Wasm container into Kubernetes
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -107,7 +107,7 @@ Once the build command ran successfully, you should see the `rd-spin-hello-world
 
 Create a `Dockerfile` with below code to package the `Wasm` module as a docker image.
 
-```
+```console
 FROM scratch
 COPY spin.toml /spin.toml
 COPY /target/rd-spin-hello-world.wasm /target/rd-spin-hello-world.wasm

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -36,7 +36,7 @@ Developing Wasm applications on your local machine on top of Rancher Desktop typ
 - Run the Wasm container and/or
 - Deploy the Wasm container into Kubernetes
 
-### Creating a simple app and compiling it into a Wasm module
+### Creating a Simple App and Compiling It Into a Wasm Module
 
 You can use the Spin framework from Fermyon to quickly bootstrap a simple Wasm app. Install Spin on your machine following the instructions on the [Installing Spin](https://developer.fermyon.com/spin/v2/install) page.
 
@@ -118,7 +118,7 @@ Run the command below to package the Wasm module as a container image.
 <Tabs groupId="container-runtime">
   <TabItem value="nerdctl" default>
 
-```
+```console
 nerdctl build \
   --namespace k8s.io \
   --platform wasi/wasm \
@@ -158,7 +158,7 @@ docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
   </TabItem>
 </Tabs>
 
-### Running the Wasm container
+### Running the Wasm Container
 
 Running a Wasm container directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`. Ensure you have selected `dockerd(moby)` as the container engine under [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md) to work through the steps in this section.
 
@@ -183,7 +183,7 @@ $ curl http://localhost:8080/
 Hello from Wasm container!
 ```
 
-### Running Wasm apps with Kubernetes
+### Running Wasm Apps with Kubernetes
 
 Running WebAssembly applications on Kubernetes is currently only supported with the `containerd` runtime; it doesn't work with the `cri-dockerd` shim used to run Kubernetes on top of `moby`.
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -144,7 +144,7 @@ Push the image to the container registry
 <Tabs groupId="container-runtime">
   <TabItem value="nerdctl" default>
 
-```
+```console
 nerdctl push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
 ```
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -84,7 +84,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
 Change to the app directory and run the `spin build` command to compile the app code into a Wasm module.
 
-```
+```console
 $spin build
 Building component rd-spin-hello-world with `npm run build`
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -58,7 +58,7 @@ Enter a name for your new application: rd-spin-hello-world
 ```
 
 Provide an optional description and leave the API route path to default
-```
+```console
 $spin new
 Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
 Enter a name for your new application: rd-spin-hello-world

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -141,16 +141,29 @@ docker buildx build \
 
 Push the image to the container registry
 
+<Tabs groupId="container-runtime">
+  <TabItem value="nerdctl" default>
+
+```
+nerdctl push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
+```
+
+  </TabItem>
+  <TabItem value="docker">
+
 ```
 docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Running the Wasm container
 
 Running a Wasm container directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`. Ensure you have selected `dockerd(moby)` as the container engine under [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md) to work through the steps in this section.
 
 
-The following command runs the `spin-rust-hello` sample `spin` application on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
+The following command runs the `rd-spin-hello-world` sample `spin` application, built in the previous section, on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
 
 ```
 docker run \

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -178,7 +178,7 @@ docker run \
 
 The internal port `80` has been mapped to `8080` and can be tested from the host:
 
-```
+```console
 $ curl http://localhost:8080/
 Hello from Wasm container!
 ```

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -26,9 +26,129 @@ For now additional shims can be installed by the user into the `containerd-shims
 
 Any shim installed there will automatically be copied into the VM and configured for the container engine when Rancher Desktop is started (installing a newer version of the `spin` shim will override the bundled version).
 
-## Running Wasm apps with the container engine
+## Developing Wasm applications with Rancher Desktop
 
-Running WebAssembly applications directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`.
+Developing Wasm applications on your local machine on top of Rancher Desktop typically involves below steps:
+
+- Create an application in your programming language of choice. You can compile code written in many languages, such as C, C++, Rust, Go, and others, into Wasm modules
+- Compile the code into a Wasm module
+- Package the Wasm module as a OCI contianer image and push to a container registry
+- Run the Wasm container and/or
+- Deploy the Wasm container into Kubernetes
+
+### Creating a simple app and compiling it into a Wasm module
+
+You can use the Spin framework from Fermyon to quickly bootstrap a simple Wasm app. Install Spin on your machine following the instructions on the [Installing Spin](https://developer.fermyon.com/spin/v2/install) page.
+
+Once you have successfully installed Spin, create a new app via the command `spin new`. 
+
+Select the lanaguage you would like to use for development.  
+```
+$spin new
+Pick a template to start your application with:
+  http-js (HTTP request handler using Javascript)
+> http-ts (HTTP request handler using Typescript)
+```
+
+Give a name to your app
+```
+$spin new
+Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: rd-spin-hello-world
+```
+
+Provide an optional description and leave the API route path to default
+```
+$spin new
+Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: rd-spin-hello-world
+Description []: This is a simple typescript app that will be compiled into a Wasm module and run as a Wasm container
+HTTP path:  /...
+```
+
+Once the command ran successfully, you should see a directory created with the boilerplate code for the Spin app. 
+
+Update the `index.ts` file to return a different message than the default.
+
+```
+import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  return {
+    status: 200,
+    headers: { "content-type": "text/plain" },
+    body: "Hello from Wasm container!"
+  }
+}
+```
+
+Change to the app diretory and run the `spin build` command to compile the app code into a Wasm module.
+
+```
+$spin build
+Building component rd-spin-hello-world with `npm run build`
+
+$ rd-spin-hello-world@1.0.0 build
+$ npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/rd-spin-hello-world.wasm dist/spin.js
+
+asset spin.js 4.57 KiB [compared for emit] (name: main)
+runtime modules 670 bytes 3 modules
+./src/index.ts 2.86 KiB [built] [code generated]
+webpack 5.91.0 compiled successfully in 1355 ms
+
+Starting to build Spin compatible module
+Spin compatible module built successfully
+Finished building all Spin components
+```
+
+Once the build command ran successfully, you should see the `rd-spin-hello-world.wasm` module created inside the `target` directory.
+
+### Package the Wasm module as a OCI contianer image and push to a container registry
+
+Create a `Dockerfile` with below code to package the `Wasm` module as a docker image.
+
+```
+FROM scratch
+COPY spin.toml /spin.toml
+COPY /target/rd-spin-hello-world.wasm /target/rd-spin-hello-world.wasm
+```
+
+Run the command below to package the Wasm module as a container image.
+
+<Tabs groupId="container-runtime">
+  <TabItem value="nerdctl" default>
+
+```
+nerdctl build \
+  --namespace k8s.io \
+  --platform wasi/wasm \
+  -t ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 .
+```
+
+  </TabItem>
+  <TabItem value="docker">
+
+```
+docker buildx build \
+  --load \
+  --platform wasi/wasm \
+  --provenance=false \
+  -t ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 .
+```
+
+  </TabItem>
+</Tabs>
+
+Push the image to the container registry
+
+```
+docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
+```
+
+### Running the Wasm container
+
+Running a Wasm container directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`. Ensure you have selected `dockerd(moby)` as the container engine under [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md) to work through the steps in this section.
+
 
 The following command runs the `spin-rust-hello` sample `spin` application on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
 
@@ -39,22 +159,22 @@ docker run \
     --runtime io.containerd.spin.v2 \
     --platform wasi/wasm \
     --publish 8080:80 \
-    ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.1 \
+    ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 \
     /
 ```
 
 The internal port `80` has been mapped to `8080` and can be tested from the host:
 
 ```
-$ curl http://localhost:8080/hello
-Hello world from Spin!
+$ curl http://localhost:8080/
+Hello from Wasm container!
 ```
 
-## Running Wasm apps with Kubernetes
+### Running Wasm apps with Kubernetes
 
 Running WebAssembly applications on Kubernetes is currently only supported with the `containerd` runtime; it doesn't work with the `cri-dockerd` shim used to run Kubernetes on top of `moby`.
 
-Create a deployment for the `spin-rust-hello` sample app:
+Create a deployment for the sample Wasm container image built in the previous section:
 
 ```console
 kubectl apply --filename - <<EOF
@@ -75,7 +195,7 @@ spec:
       runtimeClassName: spin
       containers:
       - name: hello-spin
-        image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.1
+        image: ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
         command: ["/"]
 EOF
 ```
@@ -132,8 +252,8 @@ ingress.networking.k8s.io/hello-spin created
 Testing it from the host:
 
 ```console
-$ curl http://localhost/hello
-Hello world from Spin!
+$ curl http://localhost/
+Hello from Wasm container!
 ```
 
 ### Ingress IP on Windows

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -151,7 +151,7 @@ nerdctl push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
   </TabItem>
   <TabItem value="docker">
 
-```
+```console
 docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
 ```
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -128,7 +128,7 @@ nerdctl build \
   </TabItem>
   <TabItem value="docker">
 
-```
+```console
 docker buildx build \
   --load \
   --platform wasi/wasm \

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -43,7 +43,7 @@ You can use the Spin framework from Fermyon to quickly bootstrap a simple Wasm a
 Once you have successfully installed Spin, create a new app via the command `spin new`. 
 
 Select the language you would like to use for development.  
-```
+```console
 $spin new
 Pick a template to start your application with:
   http-js (HTTP request handler using Javascript)

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -165,7 +165,7 @@ Running a Wasm container directly is currently only supported with the `moby` co
 
 The following command runs the `rd-spin-hello-world` sample `spin` application, built in the previous section, on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
 
-```
+```console
 docker run \
     --detach \
     --name spin-demo \

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -42,7 +42,7 @@ You can use the Spin framework from Fermyon to quickly bootstrap a simple Wasm a
 
 Once you have successfully installed Spin, create a new app via the command `spin new`. 
 
-Select the lanaguage you would like to use for development.  
+Select the language you would like to use for development.  
 ```
 $spin new
 Pick a template to start your application with:

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -70,7 +70,7 @@ Once the command ran successfully, you should see a directory created with the b
 
 Update the `index.ts` file to return a different message than the default.
 
-```
+```console
 import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
 
 export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {

--- a/versioned_docs/version-1.13/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.13/tutorials/working-with-webassembly.md
@@ -141,16 +141,29 @@ docker buildx build \
 
 Push the image to the container registry
 
+<Tabs groupId="container-runtime">
+  <TabItem value="nerdctl" default>
+
+```
+nerdctl push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
+```
+
+  </TabItem>
+  <TabItem value="docker">
+
 ```
 docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Running the Wasm container
 
 Running a Wasm container directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`. Ensure you have selected `dockerd(moby)` as the container engine under [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md) to work through the steps in this section.
 
 
-The following command runs the `spin-rust-hello` sample `spin` application on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
+The following command runs the `rd-spin-hello-world` sample `spin` application, built in the previous section, on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
 
 ```
 docker run \

--- a/versioned_docs/version-1.13/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.13/tutorials/working-with-webassembly.md
@@ -26,9 +26,129 @@ For now additional shims can be installed by the user into the `containerd-shims
 
 Any shim installed there will automatically be copied into the VM and configured for the container engine when Rancher Desktop is started (installing a newer version of the `spin` shim will override the bundled version).
 
-## Running Wasm apps with the container engine
+## Developing Wasm applications with Rancher Desktop
 
-Running WebAssembly applications directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`.
+Developing Wasm applications on your local machine on top of Rancher Desktop typically involves below steps:
+
+- Create an application in your programming language of choice. You can compile code written in many languages, such as C, C++, Rust, Go, and others, into Wasm modules
+- Compile the code into a Wasm module
+- Package the Wasm module as a OCI contianer image and push to a container registry
+- Run the Wasm container and/or
+- Deploy the Wasm container into Kubernetes
+
+### Creating a simple app and compiling it into a Wasm module
+
+You can use the Spin framework from Fermyon to quickly bootstrap a simple Wasm app. Install Spin on your machine following the instructions on the [Installing Spin](https://developer.fermyon.com/spin/v2/install) page.
+
+Once you have successfully installed Spin, create a new app via the command `spin new`. 
+
+Select the lanaguage you would like to use for development.  
+```
+$spin new
+Pick a template to start your application with:
+  http-js (HTTP request handler using Javascript)
+> http-ts (HTTP request handler using Typescript)
+```
+
+Give a name to your app
+```
+$spin new
+Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: rd-spin-hello-world
+```
+
+Provide an optional description and leave the API route path to default
+```
+$spin new
+Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: rd-spin-hello-world
+Description []: This is a simple typescript app that will be compiled into a Wasm module and run as a Wasm container
+HTTP path:  /...
+```
+
+Once the command ran successfully, you should see a directory created with the boilerplate code for the Spin app. 
+
+Update the `index.ts` file to return a different message than the default.
+
+```
+import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  return {
+    status: 200,
+    headers: { "content-type": "text/plain" },
+    body: "Hello from Wasm container!"
+  }
+}
+```
+
+Change to the app diretory and run the `spin build` command to compile the app code into a Wasm module.
+
+```
+$spin build
+Building component rd-spin-hello-world with `npm run build`
+
+$ rd-spin-hello-world@1.0.0 build
+$ npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/rd-spin-hello-world.wasm dist/spin.js
+
+asset spin.js 4.57 KiB [compared for emit] (name: main)
+runtime modules 670 bytes 3 modules
+./src/index.ts 2.86 KiB [built] [code generated]
+webpack 5.91.0 compiled successfully in 1355 ms
+
+Starting to build Spin compatible module
+Spin compatible module built successfully
+Finished building all Spin components
+```
+
+Once the build command ran successfully, you should see the `rd-spin-hello-world.wasm` module created inside the `target` directory.
+
+### Package the Wasm module as a OCI contianer image and push to a container registry
+
+Create a `Dockerfile` with below code to package the `Wasm` module as a docker image.
+
+```
+FROM scratch
+COPY spin.toml /spin.toml
+COPY /target/rd-spin-hello-world.wasm /target/rd-spin-hello-world.wasm
+```
+
+Run the command below to package the Wasm module as a container image.
+
+<Tabs groupId="container-runtime">
+  <TabItem value="nerdctl" default>
+
+```
+nerdctl build \
+  --namespace k8s.io \
+  --platform wasi/wasm \
+  -t ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 .
+```
+
+  </TabItem>
+  <TabItem value="docker">
+
+```
+docker buildx build \
+  --load \
+  --platform wasi/wasm \
+  --provenance=false \
+  -t ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 .
+```
+
+  </TabItem>
+</Tabs>
+
+Push the image to the container registry
+
+```
+docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
+```
+
+### Running the Wasm container
+
+Running a Wasm container directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`. Ensure you have selected `dockerd(moby)` as the container engine under [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md) to work through the steps in this section.
+
 
 The following command runs the `spin-rust-hello` sample `spin` application on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
 
@@ -39,22 +159,22 @@ docker run \
     --runtime io.containerd.spin.v2 \
     --platform wasi/wasm \
     --publish 8080:80 \
-    ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.1 \
+    ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 \
     /
 ```
 
 The internal port `80` has been mapped to `8080` and can be tested from the host:
 
 ```
-$ curl http://localhost:8080/hello
-Hello world from Spin!
+$ curl http://localhost:8080/
+Hello from Wasm container!
 ```
 
-## Running Wasm apps with Kubernetes
+### Running Wasm apps with Kubernetes
 
 Running WebAssembly applications on Kubernetes is currently only supported with the `containerd` runtime; it doesn't work with the `cri-dockerd` shim used to run Kubernetes on top of `moby`.
 
-Create a deployment for the `spin-rust-hello` sample app:
+Create a deployment for the sample Wasm container image built in the previous section:
 
 ```console
 kubectl apply --filename - <<EOF
@@ -75,7 +195,7 @@ spec:
       runtimeClassName: spin
       containers:
       - name: hello-spin
-        image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.1
+        image: ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
         command: ["/"]
 EOF
 ```
@@ -132,8 +252,8 @@ ingress.networking.k8s.io/hello-spin created
 Testing it from the host:
 
 ```console
-$ curl http://localhost/hello
-Hello world from Spin!
+$ curl http://localhost/
+Hello from Wasm container!
 ```
 
 ### Ingress IP on Windows

--- a/versioned_docs/version-latest/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-latest/tutorials/working-with-webassembly.md
@@ -141,16 +141,29 @@ docker buildx build \
 
 Push the image to the container registry
 
+<Tabs groupId="container-runtime">
+  <TabItem value="nerdctl" default>
+
+```
+nerdctl push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
+```
+
+  </TabItem>
+  <TabItem value="docker">
+
 ```
 docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Running the Wasm container
 
 Running a Wasm container directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`. Ensure you have selected `dockerd(moby)` as the container engine under [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md) to work through the steps in this section.
 
 
-The following command runs the `spin-rust-hello` sample `spin` application on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
+The following command runs the `rd-spin-hello-world` sample `spin` application, built in the previous section, on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
 
 ```
 docker run \

--- a/versioned_docs/version-latest/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-latest/tutorials/working-with-webassembly.md
@@ -26,9 +26,129 @@ For now additional shims can be installed by the user into the `containerd-shims
 
 Any shim installed there will automatically be copied into the VM and configured for the container engine when Rancher Desktop is started (installing a newer version of the `spin` shim will override the bundled version).
 
-## Running Wasm apps with the container engine
+## Developing Wasm applications with Rancher Desktop
 
-Running WebAssembly applications directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`.
+Developing Wasm applications on your local machine on top of Rancher Desktop typically involves below steps:
+
+- Create an application in your programming language of choice. You can compile code written in many languages, such as C, C++, Rust, Go, and others, into Wasm modules
+- Compile the code into a Wasm module
+- Package the Wasm module as a OCI contianer image and push to a container registry
+- Run the Wasm container and/or
+- Deploy the Wasm container into Kubernetes
+
+### Creating a simple app and compiling it into a Wasm module
+
+You can use the Spin framework from Fermyon to quickly bootstrap a simple Wasm app. Install Spin on your machine following the instructions on the [Installing Spin](https://developer.fermyon.com/spin/v2/install) page.
+
+Once you have successfully installed Spin, create a new app via the command `spin new`. 
+
+Select the lanaguage you would like to use for development.  
+```
+$spin new
+Pick a template to start your application with:
+  http-js (HTTP request handler using Javascript)
+> http-ts (HTTP request handler using Typescript)
+```
+
+Give a name to your app
+```
+$spin new
+Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: rd-spin-hello-world
+```
+
+Provide an optional description and leave the API route path to default
+```
+$spin new
+Pick a template to start your application with: http-ts (HTTP request handler using Typescript)
+Enter a name for your new application: rd-spin-hello-world
+Description []: This is a simple typescript app that will be compiled into a Wasm module and run as a Wasm container
+HTTP path:  /...
+```
+
+Once the command ran successfully, you should see a directory created with the boilerplate code for the Spin app. 
+
+Update the `index.ts` file to return a different message than the default.
+
+```
+import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  return {
+    status: 200,
+    headers: { "content-type": "text/plain" },
+    body: "Hello from Wasm container!"
+  }
+}
+```
+
+Change to the app diretory and run the `spin build` command to compile the app code into a Wasm module.
+
+```
+$spin build
+Building component rd-spin-hello-world with `npm run build`
+
+$ rd-spin-hello-world@1.0.0 build
+$ npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/rd-spin-hello-world.wasm dist/spin.js
+
+asset spin.js 4.57 KiB [compared for emit] (name: main)
+runtime modules 670 bytes 3 modules
+./src/index.ts 2.86 KiB [built] [code generated]
+webpack 5.91.0 compiled successfully in 1355 ms
+
+Starting to build Spin compatible module
+Spin compatible module built successfully
+Finished building all Spin components
+```
+
+Once the build command ran successfully, you should see the `rd-spin-hello-world.wasm` module created inside the `target` directory.
+
+### Package the Wasm module as a OCI contianer image and push to a container registry
+
+Create a `Dockerfile` with below code to package the `Wasm` module as a docker image.
+
+```
+FROM scratch
+COPY spin.toml /spin.toml
+COPY /target/rd-spin-hello-world.wasm /target/rd-spin-hello-world.wasm
+```
+
+Run the command below to package the Wasm module as a container image.
+
+<Tabs groupId="container-runtime">
+  <TabItem value="nerdctl" default>
+
+```
+nerdctl build \
+  --namespace k8s.io \
+  --platform wasi/wasm \
+  -t ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 .
+```
+
+  </TabItem>
+  <TabItem value="docker">
+
+```
+docker buildx build \
+  --load \
+  --platform wasi/wasm \
+  --provenance=false \
+  -t ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 .
+```
+
+  </TabItem>
+</Tabs>
+
+Push the image to the container registry
+
+```
+docker push ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
+```
+
+### Running the Wasm container
+
+Running a Wasm container directly is currently only supported with the `moby` container engine; there is a bug in `nerdctl` that prevents it from working with `containerd`. Ensure you have selected `dockerd(moby)` as the container engine under [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md) to work through the steps in this section.
+
 
 The following command runs the `spin-rust-hello` sample `spin` application on the `moby` engine (note the final `/` on the last line; it is the command to run, and `docker run` will fail if it is omitted):
 
@@ -39,22 +159,22 @@ docker run \
     --runtime io.containerd.spin.v2 \
     --platform wasi/wasm \
     --publish 8080:80 \
-    ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.1 \
+    ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0 \
     /
 ```
 
 The internal port `80` has been mapped to `8080` and can be tested from the host:
 
 ```
-$ curl http://localhost:8080/hello
-Hello world from Spin!
+$ curl http://localhost:8080/
+Hello from Wasm container!
 ```
 
-## Running Wasm apps with Kubernetes
+### Running Wasm apps with Kubernetes
 
 Running WebAssembly applications on Kubernetes is currently only supported with the `containerd` runtime; it doesn't work with the `cri-dockerd` shim used to run Kubernetes on top of `moby`.
 
-Create a deployment for the `spin-rust-hello` sample app:
+Create a deployment for the sample Wasm container image built in the previous section:
 
 ```console
 kubectl apply --filename - <<EOF
@@ -75,7 +195,7 @@ spec:
       runtimeClassName: spin
       containers:
       - name: hello-spin
-        image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.1
+        image: ghcr.io/rancher-sandbox/rd-spin-hello-world:0.1.0
         command: ["/"]
 EOF
 ```
@@ -132,8 +252,8 @@ ingress.networking.k8s.io/hello-spin created
 Testing it from the host:
 
 ```console
-$ curl http://localhost/hello
-Hello world from Spin!
+$ curl http://localhost/
+Hello from Wasm container!
 ```
 
 ### Ingress IP on Windows


### PR DESCRIPTION
Expanded the tutorial to start from a simple hello-world program, compile it to a Wasm module and then package and run as a container. I have tested the provided steps on Windows. The steps need to be tested on macOS and Linux as part of the PR review.