### PR TITLE
Update Algolia Crawler - Search API Key

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,7 +68,7 @@ const config = {
         appId: 'LLF7X2GYUC',
   
         // Public API key: it is safe to commit it
-        apiKey: 'd6a776aab735c97bf947305429450c53',
+        apiKey: 'e279fcdc00514b0cf0cf2608bbf9928a',
   
         indexName: 'rancherdesktop',
   


### PR DESCRIPTION
Updating the Algolia search API key as crawler is blocked currently from scraping the site with incorrect key.