### PR TITLE
Update transfer-container-images.md

### DIFF
--- a/docs/how-to-guides/transfer-container-images.md
+++ b/docs/how-to-guides/transfer-container-images.md
@@ -108,7 +108,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/transfer-container-images.md
@@ -104,7 +104,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/transfer-container-images.md
@@ -107,7 +107,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/transfer-container-images.md
@@ -104,7 +104,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/transfer-container-images.md
@@ -104,7 +104,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/how-to-guides/transfer-container-images.md
@@ -107,7 +107,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/how-to-guides/transfer-container-images.md
@@ -107,7 +107,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9-tech-preview/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9-tech-preview/how-to-guides/transfer-container-images.md
@@ -107,7 +107,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/transfer-container-images.md
@@ -107,7 +107,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/transfer-container-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/transfer-container-images.md
@@ -104,7 +104,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
 </TabItem>

--- a/versioned_docs/version-1.10/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.10/how-to-guides/transfer-container-images.md
@@ -108,7 +108,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-1.11/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.11/how-to-guides/transfer-container-images.md
@@ -108,7 +108,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-1.12/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.12/how-to-guides/transfer-container-images.md
@@ -108,7 +108,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-1.13/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.13/how-to-guides/transfer-container-images.md
@@ -108,7 +108,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-1.7/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.7/how-to-guides/transfer-container-images.md
@@ -111,7 +111,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-1.8/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.8/how-to-guides/transfer-container-images.md
@@ -111,7 +111,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-1.9-tech-preview/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.9-tech-preview/how-to-guides/transfer-container-images.md
@@ -107,7 +107,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-1.9/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.9/how-to-guides/transfer-container-images.md
@@ -111,7 +111,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>

--- a/versioned_docs/version-latest/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-latest/how-to-guides/transfer-container-images.md
@@ -108,7 +108,7 @@ nerdctl load < local-images.tar
   <TabItem value="docker">
 
 ```
-docker load < local-images.tar
+docker load -i local-images.tar
 ```
 
   </TabItem>


### PR DESCRIPTION
Acording to docker load help, the option is a "-i" and not a "<"


Usage:  docker load [OPTIONS]
Load an image from a tar archive or STDIN
Aliases:
  docker image load, docker load

Options:
  -i, --input string   Read from tar archive file, instead of STDIN
  -q, --quiet          Suppress the load output