### PR TITLE
Update WSL Integration info about ~/.kube/config

### DIFF
--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -16,14 +16,18 @@ With WSL, memory and CPU allocation is configured globally across all Linux dist
 [WSL documentation]:
 https://docs.microsoft.com/en-us/windows/wsl/wsl-config#options-for-wslconfig
 
-:::caution warning: breaking change
+### `~/.kube/config`
+
+Rancher Desktop will create a symlink from `~/.kube/config` inside the distro to the corresponding `%USERPROFILE%\.kube\config` file on the Windows filesystem.
+
+If the `~/.kube/config` file already exists inside the distro and contains only `rancher-desktop` contexts, users, and clusters then it will be deleted and replaced with the symlink.
+
+If it contains any other information then the file will not be modified and the user has to update the Rancher Desktop cluster information manually. In that case the "Kubernetes context" menu entry for the notification icon will show (and change) the context for the Win32 side only. The contexts inside distributions will need to be managed manually from a command prompt.
+
+:::caution info
+
+In Rancher Desktop `1.11.1` and `1.12.*` the `~/.kube/config` file was converted from a symlink into a regular file because the network tunnelling option required a different Kubernetes endpoint inside WSL clusters than on the host.
+
+Rancher Desktop `1.13.0` added a network proxy between the cluster and the other distros, so the endpoint is the same again as on the host. If the `~/.kube/config` file only references the `rancher-desktop` cluster then it will automatically be converted into a symlink again. Otherwise the user need to consolidate the different files manually. 
 
 :::
-
-Starting with version `1.11.1`, Rancher Desktop no longer supports a symlink from the `~/.kube/config` file to the instance on your Windows filesystem. This is due to the Kubernetes endpoint differing between the Windows host and inside a WSL2 distribution. The application will replace found symlinks with a separate file instead.
-
-If the file inside the distribution is a separate file, or a symlink to any other location, then Rancher Desktop will update that file with the `rancher-desktop` context.
-
-However, if the file is a symlink to the default location on the host, then Rancher Desktop will delete it and create a new file with the cluster configuration that works from inside the distribution.
-
-Consequently, the "Kubernetes context" menu entry for the notification will show (and change) the context for the Win32 side only. The contexts inside distributions will need to be managed manually from a command prompt.


### PR DESCRIPTION
Starting with 1.13.0 the file became a symlink again.

This change should also be merged into the 1.13 branch of the docs.

Fixes #360