### PR TITLE
Correct path for Rancher Desktop provisioning in open file limit guide

### DIFF
--- a/docs/how-to-guides/increasing-open-file-limit.md
+++ b/docs/how-to-guides/increasing-open-file-limit.md
@@ -66,7 +66,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/docs/how-to-guides/mirror-private-registry.md
+++ b/docs/how-to-guides/mirror-private-registry.md
@@ -83,7 +83,7 @@ Ensure that you have initialized the application with a first run in order to cr
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 
 `.start` File Path:
-`$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start`
+`$HOME\AppData\Local\rancher-desktop\provisioning\mirror-registry.start`
 
 Example Script:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/increasing-open-file-limit.md
@@ -62,7 +62,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/provisioning-scripts.md
@@ -63,7 +63,7 @@ env:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -73,7 +73,7 @@ env:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/increasing-open-file-limit.md
@@ -64,7 +64,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/provisioning-scripts.md
@@ -54,7 +54,7 @@ mounts:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -64,7 +64,7 @@ mounts:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/increasing-open-file-limit.md
@@ -62,7 +62,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/provisioning-scripts.md
@@ -63,7 +63,7 @@ env:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -73,7 +73,7 @@ env:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/increasing-open-file-limit.md
@@ -62,7 +62,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/provisioning-scripts.md
@@ -63,7 +63,7 @@ env:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -73,7 +73,7 @@ env:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.6/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.6/how-to-guides/increasing-open-file-limit.md
@@ -64,7 +64,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.6/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.6/how-to-guides/provisioning-scripts.md
@@ -53,7 +53,7 @@ mounts:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -63,7 +63,7 @@ mounts:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.6/references/rdctl-command-reference.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.6/references/rdctl-command-reference.md
@@ -37,7 +37,7 @@ Available Commands:
   version       Shows the CLI version
 
 Flags:
-      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Roaming\rancher-desktop\rd-engine.json)
+      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Local\rancher-desktop\rd-engine.json)
   -h, --help                 help for rdctl
       --host string          default is localhost; most useful for WSL
       --password string      overrides the password setting in the config file

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/how-to-guides/increasing-open-file-limit.md
@@ -64,7 +64,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/how-to-guides/provisioning-scripts.md
@@ -54,7 +54,7 @@ mounts:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -64,7 +64,7 @@ mounts:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/references/rdctl-command-reference.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/references/rdctl-command-reference.md
@@ -37,7 +37,7 @@ Available Commands:
   version       Shows the CLI version
 
 Flags:
-      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Roaming\rancher-desktop\rd-engine.json)
+      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Local\rancher-desktop\rd-engine.json)
   -h, --help                 help for rdctl
       --host string          default is localhost; most useful for WSL
       --password string      overrides the password setting in the config file

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/how-to-guides/increasing-open-file-limit.md
@@ -64,7 +64,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/how-to-guides/provisioning-scripts.md
@@ -54,7 +54,7 @@ mounts:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -64,7 +64,7 @@ mounts:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/references/rdctl-command-reference.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/references/rdctl-command-reference.md
@@ -37,7 +37,7 @@ Available Commands:
   version       Shows the CLI version
 
 Flags:
-      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Roaming\rancher-desktop\rd-engine.json)
+      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Local\rancher-desktop\rd-engine.json)
   -h, --help                 help for rdctl
       --host string          default is localhost; most useful for WSL
       --password string      overrides the password setting in the config file

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9-tech-preview/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9-tech-preview/how-to-guides/increasing-open-file-limit.md
@@ -64,7 +64,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9-tech-preview/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9-tech-preview/how-to-guides/provisioning-scripts.md
@@ -54,7 +54,7 @@ mounts:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -64,7 +64,7 @@ mounts:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/increasing-open-file-limit.md
@@ -64,7 +64,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/provisioning-scripts.md
@@ -63,7 +63,7 @@ env:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -73,7 +73,7 @@ env:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/increasing-open-file-limit.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/increasing-open-file-limit.md
@@ -62,7 +62,7 @@ provision:
 
 首先，确保 Rancher Desktop 至少运行过一次来初始化配置。
 
-然后，使用以下代码在 `%AppData%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
+然后，使用以下代码在 `%LOCALAPPDATA%\rancher-desktop\provisioning` 中创建一个配置脚本，比如 `map_count.start`，这样能通过增加 `max_map_count` 参数的值来更新打开文件的限制。
 
 ```
 #!/bin/sh

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/provisioning-scripts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/provisioning-scripts.md
@@ -63,7 +63,7 @@ env:
 
 - 你需要至少运行 Rancher Desktop 一次以允许它创建配置。
 
-- 打开 `%AppData%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Roaming\\rancher-desktop\\provisioning`。
+- 打开 `%LOCALAPPDATA%\\rancher-desktop\\provisioning` 目录。完整路径的示例：`C:\\Users\\Joe\\AppData\\Local\\rancher-desktop\\provisioning`。
 
 - 请注意，任何文件扩展名为 `.start` 的文件（例如 `k3s-overrides.start`）都可以在 _Rancher Desktop 启动 Kubernetes 后端（如果启用）_ 时执行。此类文件将在 Rancher Desktop WSL 上下文中运行。
 
@@ -73,7 +73,7 @@ env:
 - 在 UI 中启用 `dockerd` 或 `containerd`
 - Kubernetes (K3s)
 
-例如，使用 `%AppData%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
+例如，使用 `%LOCALAPPDATA%\\rancher-desktop\\provisioning\\insecure-registry.start` 将允许 `nerdctl` 默认使用不安全的镜像仓库：
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.10/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.10/how-to-guides/increasing-open-file-limit.md
@@ -66,7 +66,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.10/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.10/how-to-guides/provisioning-scripts.md
@@ -77,7 +77,7 @@ env:
 Please note that the directory will be deleted during a factory-reset, so ensure a backup for your provisioning scripts in case you need them after factory-reset.
 :::
 
-- Open the `%AppData%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Roaming\rancher-desktop\provisioning`.
+- Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
 - Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
 
@@ -87,7 +87,7 @@ Example flow for `.start` files:
 - Enable `dockerd` or `containerd` in the UI
 - Kubernetes (K3s)
 
-As an example, using `%AppData%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
+As an example, using `%LOCALAPPDATA%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.11/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.11/how-to-guides/increasing-open-file-limit.md
@@ -66,7 +66,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.11/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.11/how-to-guides/provisioning-scripts.md
@@ -77,7 +77,7 @@ env:
 Please note that the directory will be deleted during a factory-reset, so ensure a backup for your provisioning scripts in case you need them after factory-reset.
 :::
 
-- Open the `%AppData%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Roaming\rancher-desktop\provisioning`.
+- Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
 - Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
 
@@ -87,7 +87,7 @@ Example flow for `.start` files:
 - Enable `dockerd` or `containerd` in the UI
 - Kubernetes (K3s)
 
-As an example, using `%AppData%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
+As an example, using `%LOCALAPPDATA%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.12/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.12/how-to-guides/increasing-open-file-limit.md
@@ -66,7 +66,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.12/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.12/how-to-guides/mirror-private-registry.md
@@ -83,7 +83,7 @@ Ensure that you have initialized the application with a first run in order to cr
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 
 `.start` File Path:
-`$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start`
+`$HOME\AppData\Local\rancher-desktop\provisioning\mirror-registry.start`
 
 Example Script:
 

--- a/versioned_docs/version-1.13/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.13/how-to-guides/increasing-open-file-limit.md
@@ -66,7 +66,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.13/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.13/how-to-guides/mirror-private-registry.md
@@ -83,7 +83,7 @@ Ensure that you have initialized the application with a first run in order to cr
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 
 `.start` File Path:
-`$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start`
+`$HOME\AppData\Local\rancher-desktop\provisioning\mirror-registry.start`
 
 Example Script:
 

--- a/versioned_docs/version-1.14/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.14/how-to-guides/increasing-open-file-limit.md
@@ -66,7 +66,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.14/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.14/how-to-guides/mirror-private-registry.md
@@ -83,7 +83,7 @@ Ensure that you have initialized the application with a first run in order to cr
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 
 `.start` File Path:
-`$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start`
+`$HOME\AppData\Local\rancher-desktop\provisioning\mirror-registry.start`
 
 Example Script:
 

--- a/versioned_docs/version-1.6/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.6/how-to-guides/increasing-open-file-limit.md
@@ -68,7 +68,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.6/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.6/how-to-guides/provisioning-scripts.md
@@ -57,7 +57,7 @@ mounts:
 
 - Run Rancher Desktop at least once to allow it to create its configuration.
 
-- Open the `%AppData%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Roaming\rancher-desktop\provisioning`.
+- Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
 - Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
 
@@ -67,7 +67,7 @@ Example flow for `.start` files:
 - Enable `dockerd` or `containerd` in the UI
 - Kubernetes (K3s)
 
-As an example, using `%AppData%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
+As an example, using `%LOCALAPPDATA%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.6/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.6/references/rdctl-command-reference.md
@@ -41,7 +41,7 @@ Available Commands:
   version       Shows the CLI version
 
 Flags:
-      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Roaming\rancher-desktop\rd-engine.json)
+      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Local\rancher-desktop\rd-engine.json)
   -h, --help                 help for rdctl
       --host string          default is localhost; most useful for WSL
       --password string      overrides the password setting in the config file

--- a/versioned_docs/version-1.7/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.7/how-to-guides/increasing-open-file-limit.md
@@ -68,7 +68,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
@@ -58,7 +58,7 @@ mounts:
 
 - Run Rancher Desktop at least once to allow it to create its configuration.
 
-- Open the `%AppData%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Roaming\rancher-desktop\provisioning`.
+- Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
 - Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
 
@@ -68,7 +68,7 @@ Example flow for `.start` files:
 - Enable `dockerd` or `containerd` in the UI
 - Kubernetes (K3s)
 
-As an example, using `%AppData%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
+As an example, using `%LOCALAPPDATA%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.7/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.7/references/rdctl-command-reference.md
@@ -41,7 +41,7 @@ Available Commands:
   version       Shows the CLI version
 
 Flags:
-      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Roaming\rancher-desktop\rd-engine.json)
+      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Local\rancher-desktop\rd-engine.json)
   -h, --help                 help for rdctl
       --host string          default is localhost; most useful for WSL
       --password string      overrides the password setting in the config file

--- a/versioned_docs/version-1.8/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.8/how-to-guides/increasing-open-file-limit.md
@@ -68,7 +68,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.8/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.8/how-to-guides/provisioning-scripts.md
@@ -58,7 +58,7 @@ mounts:
 
 - Run Rancher Desktop at least once to allow it to create its configuration.
 
-- Open the `%AppData%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Roaming\rancher-desktop\provisioning`.
+- Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
 - Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
 
@@ -68,7 +68,7 @@ Example flow for `.start` files:
 - Enable `dockerd` or `containerd` in the UI
 - Kubernetes (K3s)
 
-As an example, using `%AppData%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
+As an example, using `%LOCALAPPDATA%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.8/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.8/references/rdctl-command-reference.md
@@ -41,7 +41,7 @@ Available Commands:
   version       Shows the CLI version
 
 Flags:
-      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Roaming\rancher-desktop\rd-engine.json)
+      --config-path string   config file (default C:\Users\GunasekharMatamalam\AppData\Local\rancher-desktop\rd-engine.json)
   -h, --help                 help for rdctl
       --host string          default is localhost; most useful for WSL
       --password string      overrides the password setting in the config file

--- a/versioned_docs/version-1.9-tech-preview/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.9-tech-preview/how-to-guides/increasing-open-file-limit.md
@@ -64,7 +64,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.9-tech-preview/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.9-tech-preview/how-to-guides/provisioning-scripts.md
@@ -54,7 +54,7 @@ mounts:
 
 - Run Rancher Desktop at least once to allow it to create its configuration.
 
-- Open the `%AppData%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Roaming\rancher-desktop\provisioning`.
+- Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
 - Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
 
@@ -64,7 +64,7 @@ Example flow for `.start` files:
 - Enable `dockerd` or `containerd` in the UI
 - Kubernetes (K3s)
 
-As an example, using `%AppData%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
+As an example, using `%LOCALAPPDATA%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.9/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.9/how-to-guides/increasing-open-file-limit.md
@@ -68,7 +68,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
@@ -67,7 +67,7 @@ env:
 
 - Run Rancher Desktop at least once to allow it to create its configuration.
 
-- Open the `%AppData%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Roaming\rancher-desktop\provisioning`.
+- Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
 - Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
 
@@ -77,7 +77,7 @@ Example flow for `.start` files:
 - Enable `dockerd` or `containerd` in the UI
 - Kubernetes (K3s)
 
-As an example, using `%AppData%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
+As an example, using `%LOCALAPPDATA%\rancher-desktop\provisioning\insecure-registry.start` will allow `nerdctl` to use insecure registries by default:
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-latest/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-latest/how-to-guides/increasing-open-file-limit.md
@@ -66,7 +66,7 @@ Lastly, please stop and restart Rancher Desktop in order for the updated limits 
 
 First, be sure that you have run Rancher Desktop at least once in order for the configurations to initialize.
 
-You can then create a provisioning script, say `map_count.start`, at `%AppData%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
+You can then create a provisioning script, say `map_count.start`, at `%LOCALAPPDATA%\rancher-desktop\provisioning` with the below code to update the open file limit by increasing the `max_map_count` parameter.
 
 ```
 #!/bin/sh

--- a/versioned_docs/version-latest/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-latest/how-to-guides/mirror-private-registry.md
@@ -83,7 +83,7 @@ Ensure that you have initialized the application with a first run in order to cr
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 
 `.start` File Path:
-`$HOME\AppData\Roaming\rancher-desktop\provisioning\mirror-registry.start`
+`$HOME\AppData\Local\rancher-desktop\provisioning\mirror-registry.start`
 
 Example Script:
 


### PR DESCRIPTION
Resolves a contradiction with the ["Provisioning Scripts" guide](https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts/), which suggests placing *.start files in `%LOCALAPPDATA%\rancher-desktop\provisioning`.

After some head-scratching over a provisioning script in `%AppData%\rancher-desktop\provisioning` not working as expected, I think I should send this pull request to save others the same trouble.