### PR TITLE
Refine Dockerfile to copy only index.html

### DIFF
--- a/docs/how-to-guides/hello-world-example.md
+++ b/docs/how-to-guides/hello-world-example.md
@@ -85,7 +85,7 @@ vi Dockerfile
 #### Populate the Dockerfile with the command below
 ```
 FROM nginx:alpine
-COPY . /usr/share/nginx/html
+COPY ./index.html /usr/share/nginx/html
 ```
 
 #### Build image from code locally

--- a/versioned_docs/version-1.15/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.15/how-to-guides/hello-world-example.md
@@ -85,7 +85,7 @@ vi Dockerfile
 #### Populate the Dockerfile with the command below
 ```
 FROM nginx:alpine
-COPY . /usr/share/nginx/html
+COPY ./index.html /usr/share/nginx/html
 ```
 
 #### Build image from code locally


### PR DESCRIPTION
Update the Dockerfile to copy only the index.html file instead of the entire directory.  While the performance impact is minimal for small files, this change aligns with  Docker best practices and prepares for potential future project growth. It also  serves as a reminder to be mindful of what we include in our Docker images.