### PR TITLE
fixed issues with the screenshot urls for 1.16 release

### DIFF
--- a/docs/how-to-guides/installing-uninstalling-extensions.md
+++ b/docs/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions.png) 
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/extensions.md
+++ b/docs/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions-Installed.png)
+![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/getting-started/deployment.md
+++ b/versioned_docs/version-1.15/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_kubernetes_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_kubernetes_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_kubernetes_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/getting-started/introduction.md
+++ b/versioned_docs/version-1.15/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/getting-started/introduction_preferences_tabKubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.15/ui/containers.md
+++ b/versioned_docs/version-1.15/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Containers.png)
+![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Containers.png)
+![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Containers.png)
+![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/diagnostics.md
+++ b/versioned_docs/version-1.15/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Diagnostics.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Diagnostics.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Diagnostics.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/general.md
+++ b/versioned_docs/version-1.15/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_General.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_General.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_General.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/images.md
+++ b/versioned_docs/version-1.15/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Images.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Images.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Images.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/port-forwarding.md
+++ b/versioned_docs/version-1.15/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_PortForwarding.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_PortForwarding.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_PortForwarding.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_application_tabBehavior.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabBehavior.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabBehavior.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.15/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabEnvironment.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabEnvironment.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.15/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_application_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.15/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.15/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.15/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.15/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_kubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_kubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_kubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabHardware.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabHardware.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.15/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_wsl_tabIntegrations.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.15/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.15/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_wsl_tabProxy.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.15/ui/snapshots.md
+++ b/versioned_docs/version-1.15/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/troubleshooting.md
+++ b/versioned_docs/version-1.15/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Troubleshooting.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Troubleshooting.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Troubleshooting.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/getting-started/deployment.md
+++ b/versioned_docs/version-latest/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_kubernetes_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_kubernetes_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_kubernetes_lockedFields.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/getting-started/introduction.md
+++ b/versioned_docs/version-latest/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/getting-started/introduction_preferences_tabKubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-latest/ui/containers.md
+++ b/versioned_docs/version-latest/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Containers.png)
+![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Containers.png)
+![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Containers.png)
+![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/diagnostics.md
+++ b/versioned_docs/version-latest/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Diagnostics.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Diagnostics.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Diagnostics.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/general.md
+++ b/versioned_docs/version-latest/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_General.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_General.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_General.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/images.md
+++ b/versioned_docs/version-latest/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Images.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Images.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Images.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/port-forwarding.md
+++ b/versioned_docs/version-latest/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_PortForwarding.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_PortForwarding.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_PortForwarding.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-latest/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_application_tabBehavior.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabBehavior.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabBehavior.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-latest/ui/preferences/application/environment.md
+++ b/versioned_docs/version-latest/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabEnvironment.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabEnvironment.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-latest/ui/preferences/application/general.md
+++ b/versioned_docs/version-latest/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_application_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-latest/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-latest/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-latest/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabGeneral.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-latest/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_kubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_kubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_kubernetes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabHardware.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabHardware.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_wsl_tabIntegrations.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-latest/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_wsl_tabProxy.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-latest/ui/snapshots.md
+++ b/versioned_docs/version-latest/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/troubleshooting.md
+++ b/versioned_docs/version-latest/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Troubleshooting.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Troubleshooting.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Troubleshooting.png)
+![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Follow up to the PR https://github.com/rancher-sandbox/docs.rancherdesktop.io/pull/393 
- Rolled back the unintentional 1.15 to 1.16 replacement in "1.15" and "latest" folders
- Updated the "docs" folder to replace "1.15" with "1.16" for the instances missed in the previous PR