### PR TITLE
Wrap the macOS override path in quotes to prevent splitting

### DIFF
--- a/versioned_docs/version-latest/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-latest/how-to-guides/increasing-open-file-limit.md
@@ -20,7 +20,7 @@ First, use lima override.yaml to write the provisioning scripts.
   <TabItem value="macOS">
 
 ```
-~/Library/Application Support/rancher-desktop/lima/_config/override.yaml
+"~/Library/Application Support/rancher-desktop/lima/_config/override.yaml"
 ```
 
   </TabItem>


### PR DESCRIPTION
In order to help people avoid the same mistake I just made, this PR wraps the system path for override.yaml in quotes, preventing shells from splitting on the space in "Application Support".