### PR TITLE
Tutorials: Storage: Quote arguments for PowerShell

### DIFF
--- a/docs/tutorials/using-persistent-storage.md
+++ b/docs/tutorials/using-persistent-storage.md
@@ -85,7 +85,7 @@ docker container run --rm -it --mount=type=bind,source=$(pwd)/src,target=/app/sr
 nerdctl container run --rm -it --mount=type=bind,source=%cd%/src,target=/app/src alpine:latest /bin/sh
 
 // Powershell
-nerdctl container run --rm -it --mount=type=bind,source=${pwd}/src,target=/app/src alpine:latest /bin/sh
+nerdctl container run --rm -it --mount="type=bind,source=${pwd}/src,target=/app/src" alpine:latest /bin/sh
 ```
   </TabItem>
   <TabItem value="docker">
@@ -95,7 +95,7 @@ nerdctl container run --rm -it --mount=type=bind,source=${pwd}/src,target=/app/s
 docker container run --rm -it --mount=type=bind,source=%cd%/src,target=/app/src alpine:latest /bin/sh
 
 // Powershell
-docker container run --rm -it --mount=type=bind,source=${pwd}/src,target=/app/src alpine:latest /bin/sh
+docker container run --rm -it --mount="type=bind,source=${pwd}/src,target=/app/src" alpine:latest /bin/sh
 ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
When using pwsh (PowerShell 7.x), variable expansion doesn't seem to happen in the middle of arguments unless they're within double quotes.  Except that they do get expanded when checking with `echo`.

See: https://github.com/rancher-sandbox/rancher-desktop/issues/6900

(I think the user has _different_ problems, but the issue here was a red herring.)