### PR TITLE
Automate versioned image URLs

### DIFF
--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/docs/how-to-guides/installing-uninstalling-extensions.md
+++ b/docs/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/containers.md
+++ b/docs/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/diagnostics.md
+++ b/docs/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/extensions.md
+++ b/docs/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/general.md
+++ b/docs/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/images.md
+++ b/docs/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/preferences/application/behavior.md
+++ b/docs/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/docs/ui/preferences/application/environment.md
+++ b/docs/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/docs/ui/preferences/application/general.md
+++ b/docs/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/docs/ui/preferences/container-engine/allowed-images.md
+++ b/docs/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/preferences/container-engine/general.md
+++ b/docs/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/preferences/kubernetes.md
+++ b/docs/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/preferences/virtual-machine/emulation.md
+++ b/docs/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/docs/ui/preferences/virtual-machine/hardware.md
+++ b/docs/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/preferences/virtual-machine/volumes.md
+++ b/docs/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/docs/ui/preferences/wsl/proxy.md
+++ b/docs/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/docs/ui/snapshots.md
+++ b/docs/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/docs/ui/troubleshooting.md
+++ b/docs/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
+import RDVersionedAssets from './src/remark/rd-versioned-assets.js';
+
 const lightCodeTheme = require('prism-react-renderer').themes.github;
 const darkCodeTheme = require('prism-react-renderer').themes.dracula;
 
@@ -43,6 +45,7 @@ const config = {
               banner: "none"
             },
           },
+          remarkPlugins: [RDVersionedAssets],
         },
         blog: false,
         theme: {

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/deployment.md
@@ -58,23 +58,23 @@ Rancher Desktop 不会修改或删除部署配置文件。它们不会受到恢�
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/introduction.md
@@ -7,7 +7,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop 是一款在桌面上提供容器和 Kubernetes 管理的应用。它适用于 Mac（包括 Intel 和 Apple 芯片）、Windows 和 Linux。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _上图左边是 Mac 上的 Kubernetes 设置，右边是 Windows。_
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/installing-uninstalling-extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/installing-uninstalling-extensions.md
@@ -21,7 +21,7 @@ Rancher Desktop 扩展在 `v1.9.0-tech-preview` 或更高版本中提供。
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### 使用命令行
 
@@ -44,7 +44,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### 使用命令行
 
@@ -67,7 +67,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### 使用命令行
 
@@ -100,12 +100,12 @@ rdctl extension install <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -134,12 +134,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -168,12 +168,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/diagnostics.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/extensions.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -38,17 +38,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/port-forwarding.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/application/behavior.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/application/behavior.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -35,7 +35,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -60,7 +60,7 @@ Rancher Desktop 通过菜单栏中的通知图标来显示应用程序状态。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/application/environment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/application/environment.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### 配置 PATH
 
@@ -26,7 +26,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### 配置 PATH
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/application/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/application/general.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -23,7 +23,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -40,7 +40,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/container-engine/allowed-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/container-engine/allowed-images.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/container-engine/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/container-engine/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/kubernetes.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/emulation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/emulation.md
@@ -3,13 +3,13 @@ sidebar_label: 仿真
 title: 仿真（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU
 
 [QEMU](https://www.qemu.org/documentation/) 选项默认启用，用于运行来宾操作系统。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 ### VZ
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/hardware.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/hardware.md
@@ -8,12 +8,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### 启用 socket-vmnet
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/volumes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/virtual-machine/volumes.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -29,12 +29,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -64,12 +64,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/wsl/integrations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/wsl/integrations.md
@@ -5,7 +5,7 @@ title: 集成
 
 Integration 选项卡提供了一个选项，使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/wsl/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/wsl/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（Windows）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/wsl/proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/preferences/wsl/proxy.md
@@ -3,7 +3,7 @@ sidebar_label: 代理
 title: 代理
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ui/troubleshooting.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/getting-started/deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/getting-started/deployment.md
@@ -60,23 +60,23 @@ Rancher Desktop 不会修改或删除部署配置文件。它们不会受到恢�
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/getting-started/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/getting-started/introduction.md
@@ -9,7 +9,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop 是一款在桌面上提供容器和 Kubernetes 管理的应用。它适用于 Mac（包括 Intel 和 Apple 芯片）、Windows 和 Linux。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _上图左边是 Mac 上的 Kubernetes 设置，右边是 Windows。_
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/installing-uninstalling-extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/how-to-guides/installing-uninstalling-extensions.md
@@ -23,7 +23,7 @@ Rancher Desktop 扩展在 `v1.9.0-tech-preview` 或更高版本中提供。
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### 使用命令行
 
@@ -46,7 +46,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### 使用命令行
 
@@ -69,7 +69,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### 使用命令行
 
@@ -99,7 +99,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。在此视图中，你可以搜索可用的扩展，并卸载已安装的扩展。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### 使用命令行
 
@@ -122,7 +122,7 @@ rdctl extension uninstall <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。在此视图中，你可以搜索可用的扩展，并卸载已安装的扩展。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### 使用命令行
 
@@ -145,7 +145,7 @@ rdctl extension uninstall <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。在此视图中，你可以搜索可用的扩展，并卸载已安装的扩展。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### 使用命令行
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/diagnostics.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/extensions.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -40,17 +40,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/general.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/images.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/port-forwarding.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/application/behavior.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/application/behavior.md
@@ -12,7 +12,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -37,7 +37,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -62,7 +62,7 @@ Rancher Desktop 通过菜单栏中的通知图标来显示应用程序状态。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/application/environment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/application/environment.md
@@ -12,7 +12,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### 配置 PATH
 
@@ -28,7 +28,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### 配置 PATH
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/application/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/application/general.md
@@ -12,7 +12,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -25,7 +25,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -42,7 +42,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/container-engine/allowed-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/container-engine/allowed-images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/container-engine/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/container-engine/general.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/kubernetes.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/emulation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/emulation.md
@@ -3,13 +3,13 @@ sidebar_label: 仿真
 title: 仿真（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabEmulation.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU
 
 [QEMU](https://www.qemu.org/documentation/) 选项默认启用，用于运行来宾操作系统。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 ### VZ
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/hardware.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/hardware.md
@@ -10,12 +10,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### 启用 socket-vmnet
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/volumes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/virtual-machine/volumes.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -29,12 +29,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -64,7 +64,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/wsl/integrations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/wsl/integrations.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 Integration 选项卡提供了一个选项，使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/wsl/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/wsl/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（Windows）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/wsl/proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/preferences/wsl/proxy.md
@@ -3,7 +3,7 @@ sidebar_label: 代理
 title: 代理
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.10/ui/troubleshooting.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/getting-started/deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/getting-started/deployment.md
@@ -58,23 +58,23 @@ Rancher Desktop 不会修改或删除部署配置文件。它们不会受到恢�
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/getting-started/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/getting-started/introduction.md
@@ -7,7 +7,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop 是一款在桌面上提供容器和 Kubernetes 管理的应用。它适用于 Mac（包括 Intel 和 Apple 芯片）、Windows 和 Linux。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _上图左边是 Mac 上的 Kubernetes 设置，右边是 Windows。_
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/installing-uninstalling-extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/how-to-guides/installing-uninstalling-extensions.md
@@ -21,7 +21,7 @@ Rancher Desktop 扩展在 `v1.9.0-tech-preview` 或更高版本中提供。
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### 使用命令行
 
@@ -44,7 +44,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### 使用命令行
 
@@ -67,7 +67,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### 使用命令行
 
@@ -100,12 +100,12 @@ rdctl extension install <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -134,12 +134,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -168,12 +168,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/diagnostics.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/extensions.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -38,17 +38,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/port-forwarding.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/application/behavior.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/application/behavior.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -35,7 +35,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -60,7 +60,7 @@ Rancher Desktop 通过菜单栏中的通知图标来显示应用程序状态。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/application/environment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/application/environment.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### 配置 PATH
 
@@ -26,7 +26,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### 配置 PATH
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/application/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/application/general.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -23,7 +23,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -40,7 +40,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/container-engine/allowed-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/container-engine/allowed-images.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/container-engine/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/container-engine/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/kubernetes.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/emulation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/emulation.md
@@ -3,13 +3,13 @@ sidebar_label: 仿真
 title: 仿真（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU
 
 [QEMU](https://www.qemu.org/documentation/) 选项默认启用，用于运行来宾操作系统。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 ### VZ
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/hardware.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/hardware.md
@@ -8,12 +8,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### 启用 socket-vmnet
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/volumes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/virtual-machine/volumes.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -29,12 +29,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -64,12 +64,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/wsl/integrations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/wsl/integrations.md
@@ -5,7 +5,7 @@ title: 集成
 
 Integration 选项卡提供了一个选项，使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/wsl/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/wsl/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（Windows）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/wsl/proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/preferences/wsl/proxy.md
@@ -3,7 +3,7 @@ sidebar_label: 代理
 title: 代理
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.11/ui/troubleshooting.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/getting-started/deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/getting-started/deployment.md
@@ -58,23 +58,23 @@ Rancher Desktop 不会修改或删除部署配置文件。它们不会受到恢�
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/getting-started/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/getting-started/introduction.md
@@ -7,7 +7,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop 是一款在桌面上提供容器和 Kubernetes 管理的应用。它适用于 Mac（包括 Intel 和 Apple 芯片）、Windows 和 Linux。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _上图左边是 Mac 上的 Kubernetes 设置，右边是 Windows。_
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/installing-uninstalling-extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/how-to-guides/installing-uninstalling-extensions.md
@@ -21,7 +21,7 @@ Rancher Desktop 扩展在 `v1.9.0-tech-preview` 或更高版本中提供。
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### 使用命令行
 
@@ -44,7 +44,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### 使用命令行
 
@@ -67,7 +67,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### 使用命令行
 
@@ -100,12 +100,12 @@ rdctl extension install <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -134,12 +134,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -168,12 +168,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/diagnostics.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/extensions.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -38,17 +38,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/port-forwarding.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/application/behavior.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/application/behavior.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -35,7 +35,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -60,7 +60,7 @@ Rancher Desktop 通过菜单栏中的通知图标来显示应用程序状态。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/application/environment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/application/environment.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### 配置 PATH
 
@@ -26,7 +26,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### 配置 PATH
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/application/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/application/general.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -23,7 +23,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -40,7 +40,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/container-engine/allowed-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/container-engine/allowed-images.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/container-engine/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/container-engine/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/kubernetes.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/emulation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/emulation.md
@@ -3,13 +3,13 @@ sidebar_label: 仿真
 title: 仿真（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU
 
 [QEMU](https://www.qemu.org/documentation/) 选项默认启用，用于运行来宾操作系统。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 ### VZ
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/hardware.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/hardware.md
@@ -8,12 +8,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### 启用 socket-vmnet
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/volumes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/virtual-machine/volumes.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -29,12 +29,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -64,12 +64,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/wsl/integrations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/wsl/integrations.md
@@ -5,7 +5,7 @@ title: 集成
 
 Integration 选项卡提供了一个选项，使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/wsl/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/wsl/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（Windows）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/wsl/proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/preferences/wsl/proxy.md
@@ -3,7 +3,7 @@ sidebar_label: 代理
 title: 代理
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.12/ui/troubleshooting.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/diagnostics.md
@@ -18,17 +18,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/general.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/images.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/port-forwarding.md
@@ -17,17 +17,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/application.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/application.md
@@ -18,7 +18,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 该选项允许 Rancher Desktop 收集关于你与 Rancher Desktop 应用程序交互的信息，但不会收集你运行的工作负载等信息。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_application.png)
+![](rd-versioned-asset://preferences/Windows_application.png)
 
 </TabItem>
 <TabItem value="macOS">
@@ -37,7 +37,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 该选项允许 Rancher Desktop 收集关于你与 Rancher Desktop 应用程序交互的信息，但不会收集你运行的工作负载等信息。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 ### Environment
 
@@ -52,7 +52,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 - **Automatic**：`PATH` 管理将通过修改你的 shell .rc 文件来将 `~/.rd/bin` 添加到 `PATH` 中。
 - **Manual**：`PATH` 管理不会改变任何东西 - 在这种模式下，你必须手动将 `~/.rd/bin` 添加到 `PATH` 中。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 </TabItem>
 <TabItem value="Linux">
@@ -71,7 +71,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 
 该选项允许 Rancher Desktop 收集关于你与 Rancher Desktop 应用程序交互的信息，但不会收集你运行的工作负载等信息。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 ### Environment
 
@@ -86,7 +86,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 - **Automatic**：`PATH` 管理将通过修改你的 shell .rc 文件来将 `~/.rd/bin` 添加到 `PATH` 中。
 - **Manual**：`PATH` 管理不会改变任何东西 - 在这种模式下，你必须手动将 `~/.rd/bin` 添加到 `PATH` 中。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/container-engine.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/container-engine.md
@@ -18,17 +18,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>
@@ -44,17 +44,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/kubernetes.md
@@ -46,17 +46,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/virtual-machine.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/virtual-machine.md
@@ -18,12 +18,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_virtualMachine.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_virtualMachine.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/wsl.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/preferences/wsl.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 该选项使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_wsl.png)
+![](rd-versioned-asset://preferences/Windows_wsl.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.7/ui/troubleshooting.md
@@ -39,17 +39,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/diagnostics.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/general.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/images.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/port-forwarding.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/application.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/application.md
@@ -14,7 +14,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -27,7 +27,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -44,7 +44,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -68,7 +68,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -89,7 +89,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -110,7 +110,7 @@ Rancher Desktop 通过菜单栏中的通知图标来显示应用程序状态。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 
@@ -138,7 +138,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### 配置 PATH
 
@@ -154,7 +154,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### 配置 PATH
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/container-engine.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/container-engine.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>
@@ -41,17 +41,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/kubernetes.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/virtual-machine.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/virtual-machine.md
@@ -10,12 +10,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_virtualMachine.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_virtualMachine.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/wsl.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/preferences/wsl.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 该选项使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_wsl.png)
+![](rd-versioned-asset://preferences/Windows_wsl.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.8/ui/troubleshooting.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/getting-started/deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/getting-started/deployment.md
@@ -60,23 +60,23 @@ Rancher Desktop 不会修改或删除部署配置文件。它们不会受到恢�
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/getting-started/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/getting-started/introduction.md
@@ -9,7 +9,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop 是一款在桌面上提供容器和 Kubernetes 管理的应用。它适用于 Mac（包括 Intel 和 Apple 芯片）、Windows 和 Linux。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _上图左边是 Mac 上的 Kubernetes 设置，右边是 Windows。_
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
@@ -23,7 +23,7 @@ Rancher Desktop 扩展在 `v1.9.0-tech-preview` 或更高版本中提供。
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### 使用命令行
 
@@ -46,7 +46,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### 使用命令行
 
@@ -69,7 +69,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### 使用命令行
 
@@ -102,12 +102,12 @@ rdctl extension install <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -136,12 +136,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -170,12 +170,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/diagnostics.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/extensions.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -40,17 +40,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/general.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/images.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/port-forwarding.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/application/behavior.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/application/behavior.md
@@ -12,7 +12,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -37,7 +37,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -62,7 +62,7 @@ Rancher Desktop 通过菜单栏中的通知图标来显示应用程序状态。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/application/environment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/application/environment.md
@@ -12,7 +12,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### 配置 PATH
 
@@ -28,7 +28,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### 配置 PATH
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/application/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/application/general.md
@@ -12,7 +12,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -25,7 +25,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -42,7 +42,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/container-engine/allowed-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/container-engine/allowed-images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/container-engine/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/container-engine/general.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/kubernetes.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/emulation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/emulation.md
@@ -3,13 +3,13 @@ sidebar_label: 仿真
 title: 仿真（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabEmulation.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU
 
 [QEMU](https://www.qemu.org/documentation/) 选项默认启用，用于运行来宾操作系统。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 ### VZ
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/hardware.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/hardware.md
@@ -10,12 +10,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### 启用 socket-vmnet
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/volumes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/virtual-machine/volumes.md
@@ -14,12 +14,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -31,12 +31,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -66,7 +66,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/wsl/integrations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/wsl/integrations.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 Integration 选项卡提供了一个选项，使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/wsl/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/wsl/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（Windows）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/wsl/proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/preferences/wsl/proxy.md
@@ -3,7 +3,7 @@ sidebar_label: 代理
 title: 代理
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-1.9/ui/troubleshooting.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/getting-started/deployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/getting-started/deployment.md
@@ -58,23 +58,23 @@ Rancher Desktop 不会修改或删除部署配置文件。它们不会受到恢�
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/getting-started/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/getting-started/introduction.md
@@ -7,7 +7,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop 是一款在桌面上提供容器和 Kubernetes 管理的应用。它适用于 Mac（包括 Intel 和 Apple 芯片）、Windows 和 Linux。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _上图左边是 Mac 上的 Kubernetes 设置，右边是 Windows。_
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
@@ -21,7 +21,7 @@ Rancher Desktop 扩展在 `v1.9.0-tech-preview` 或更高版本中提供。
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 #### 使用命令行
 
@@ -44,7 +44,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### 使用命令行
 
@@ -67,7 +67,7 @@ rdctl extension install <image-id>:<tag>
 
 单击主 UI 中的 **Extensions** 并导航到 **Catalog** 选项卡。你可以在此处搜索可用的扩展，并单击 **Install** 按钮进行下载和安装。
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### 使用命令行
 
@@ -100,12 +100,12 @@ rdctl extension install <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -134,12 +134,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -168,12 +168,12 @@ rdctl extension uninstall <image-id>:<tag>
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/diagnostics.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/diagnostics.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/extensions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/extensions.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -38,17 +38,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/port-forwarding.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/port-forwarding.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/application/behavior.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/application/behavior.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -35,7 +35,7 @@ Rancher Desktop 通过通知图标来显示应用程序的状态。图标的右�
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -60,7 +60,7 @@ Rancher Desktop 通过菜单栏中的通知图标来显示应用程序状态。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/application/environment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/application/environment.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### 配置 PATH
 
@@ -26,7 +26,7 @@ Rancher Desktop 附带命令行实用程序，用于与其各种功能交互。�
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### 配置 PATH
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/application/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/application/general.md
@@ -10,7 +10,7 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -23,7 +23,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -40,7 +40,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/container-engine/allowed-images.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/container-engine/allowed-images.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/container-engine/general.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/container-engine/general.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/kubernetes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/kubernetes.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/emulation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/emulation.md
@@ -3,13 +3,13 @@ sidebar_label: 仿真
 title: 仿真（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU
 
 [QEMU](https://www.qemu.org/documentation/) 选项默认启用，用于运行来宾操作系统。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 ### VZ
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/hardware.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/hardware.md
@@ -8,12 +8,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（macOS）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### 启用 socket-vmnet
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/volumes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/virtual-machine/volumes.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -29,12 +29,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -64,12 +64,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/wsl/integrations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/wsl/integrations.md
@@ -5,7 +5,7 @@ title: 集成
 
 Integration 选项卡提供了一个选项，使 Rancher Desktop Kubernetes 配置能够被任何 WSL 配置的 Linux 发行版所访问。一旦启用，你可以使用 WSL 发行版中的 `kubectl` 等工具与 Rancher Desktop Kubernetes 集群进行通信。
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 WSL 让你在所有 Linux 发行版中全局配置内存和 CPU 分配。请参阅 [WSL 文档]中的说明。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/wsl/network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/wsl/network.md
@@ -3,7 +3,7 @@ sidebar_label: 网络
 title: 网络（Windows）
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/wsl/proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/preferences/wsl/proxy.md
@@ -3,7 +3,7 @@ sidebar_label: 代理
 title: 代理
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-latest/ui/troubleshooting.md
@@ -8,17 +8,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/src/remark/rd-versioned-assets.js
+++ b/src/remark/rd-versioned-assets.js
@@ -1,0 +1,72 @@
+// @ts-check
+"use strict";
+
+/**
+ * This is a `remark` plugin which examines all image elements, and replaces the
+ * URL if it starts with `rd-versioned-asset://` with a versioned URL pointing
+ * at the S3 bucket we use.  For files in the `versioned_docs` directory, we use
+ * the version as listed in the file path.  For the `latest` version, as well as
+ * for the unversioned (i.e. `next`) docs, we use the maximum version listed in
+ * `versions.json` that is a valid version.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// urlPrefix is the prefix for image URLs that we will replace.
+const urlPrefix = 'rd-versioned-asset://'
+// replacementPrefix is the new URL prefix we will use.
+const replacementPrefix = 'https://suse-rancher-media.s3.amazonaws.com/desktop/'
+
+/**
+ * Walk down one node in the tree and replace image sources as needed.
+ * @param {import('mdast').Node} input The node to examine.
+ * @param {import('vfile').VFile} vfile Information about the current markdown source file.
+ * @param {string} defaultVersion The version to use if we're not in a versioned directory.
+ */
+async function processNode(input, vfile, defaultVersion) {
+    /** @type any */
+    const anyInput = input;
+    if ('children' in input) {
+        // For nodes with children, walk each child recursively.
+        /** @type import('mdast').Parent */
+        const { children } = anyInput;
+        await Promise.all(children.map(n => processNode(n, vfile, defaultVersion)));
+    }
+    if (input.type == 'image') {
+        // For each image, examine its URL and replace it as needed.
+        /** @type import('mdast').Image */
+        const image = anyInput;
+        const versionPart = vfile.path.split(path.sep).find(p => /^version-\d+\.\d+/.test(p));
+        const version = versionPart?.replace(/^version-/, 'v') ?? defaultVersion;
+        if (version === 'vlatest') {
+            throw new Error(`Invalid version! versionPart=${JSON.stringify(versionPart)} version=${JSON.stringify(version)}`);
+        }
+        if (image.url.startsWith(urlPrefix)) {
+            image.url = image.url.replace(urlPrefix, `${ replacementPrefix }${ version }/`);
+        }
+    }
+}
+
+/**
+ * @returns {import('unified').Transformer} A function to transform the markdown tree.
+ */
+export default () => {
+    return async(tree, vfile) => {
+        /** @type string[] */
+        const versions = JSON.parse(await fs.promises.readFile('versions.json', 'utf-8'));
+        const maxVersion = versions.filter(v => /^\d+\.\d+$/.test(v)).sort((a, b) => {
+            const aParts = a.split('.').map(s => parseInt(s, 10));
+            const bParts = b.split('.').map(s => parseInt(s, 10));
+            for (let i = 0; i < Math.min(aParts.length, bParts.length); i++) {
+                if (aParts[i] != bParts[i]) {
+                    return aParts[i] - bParts[i];
+                }
+            }
+            return bParts.length - aParts.length;
+        }).pop();
+        /** @type any */
+        const anyTree = tree;
+        await processNode(anyTree, vfile, `v${maxVersion}`);
+    };
+};

--- a/versioned_docs/version-1.10/getting-started/deployment.md
+++ b/versioned_docs/version-1.10/getting-started/deployment.md
@@ -62,23 +62,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/getting-started/introduction.md
+++ b/versioned_docs/version-1.10/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.10/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.10/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/diagnostics.md
+++ b/versioned_docs/version-1.10/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/extensions.md
+++ b/versioned_docs/version-1.10/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/general.md
+++ b/versioned_docs/version-1.10/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/images.md
+++ b/versioned_docs/version-1.10/ui/images.md
@@ -16,17 +16,17 @@ To manage your images using nerdctl instead, refer to the [Images](../tutorials/
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/port-forwarding.md
+++ b/versioned_docs/version-1.10/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.10/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.10/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.10/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.10/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.10/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.10/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.10/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.10/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.10/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/network.md
@@ -7,7 +7,7 @@ title: Network (macOS)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable socket-vmnet
 

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.10/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.10/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.10/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.10/ui/preferences/wsl/network.md
@@ -7,7 +7,7 @@ title: Network (Windows)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/versioned_docs/version-1.10/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.10/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.10/ui/troubleshooting.md
+++ b/versioned_docs/version-1.10/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/getting-started/deployment.md
+++ b/versioned_docs/version-1.11/getting-started/deployment.md
@@ -62,23 +62,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/getting-started/introduction.md
+++ b/versioned_docs/version-1.11/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.11/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.11/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.10/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/containers.md
+++ b/versioned_docs/version-1.11/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/diagnostics.md
+++ b/versioned_docs/version-1.11/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/extensions.md
+++ b/versioned_docs/version-1.11/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.11/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.11/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.11/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.11/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.11/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.11/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/general.md
+++ b/versioned_docs/version-1.11/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/images.md
+++ b/versioned_docs/version-1.11/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/port-forwarding.md
+++ b/versioned_docs/version-1.11/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.11/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.11/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.11/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.11/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.11/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -27,7 +27,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -44,7 +44,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.11/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.11/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.11/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.11/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/network.md
@@ -7,7 +7,7 @@ title: Network (macOS)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`
 

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.11/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.11/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.11/ui/preferences/wsl/network.md
@@ -7,7 +7,7 @@ title: Network (Windows)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/versioned_docs/version-1.11/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.11/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.11/ui/snapshots.md
+++ b/versioned_docs/version-1.11/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.11/ui/troubleshooting.md
+++ b/versioned_docs/version-1.11/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.11/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/getting-started/deployment.md
+++ b/versioned_docs/version-1.12/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/getting-started/introduction.md
+++ b/versioned_docs/version-1.12/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.12/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.12/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/containers.md
+++ b/versioned_docs/version-1.12/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/diagnostics.md
+++ b/versioned_docs/version-1.12/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/extensions.md
+++ b/versioned_docs/version-1.12/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.12/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/general.md
+++ b/versioned_docs/version-1.12/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/images.md
+++ b/versioned_docs/version-1.12/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/port-forwarding.md
+++ b/versioned_docs/version-1.12/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.12/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.12/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.12/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.12/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.12/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.12/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.12/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.12/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.12/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/network.md
@@ -7,7 +7,7 @@ title: Network (macOS)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`
 

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.12/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/network.md
@@ -7,7 +7,7 @@ title: Network (Windows)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/versioned_docs/version-1.12/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.12/ui/snapshots.md
+++ b/versioned_docs/version-1.12/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.12/ui/troubleshooting.md
+++ b/versioned_docs/version-1.12/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.12/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/getting-started/deployment.md
+++ b/versioned_docs/version-1.13/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/getting-started/introduction.md
+++ b/versioned_docs/version-1.13/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.13/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.13/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/containers.md
+++ b/versioned_docs/version-1.13/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/diagnostics.md
+++ b/versioned_docs/version-1.13/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/extensions.md
+++ b/versioned_docs/version-1.13/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.13/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/general.md
+++ b/versioned_docs/version-1.13/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/images.md
+++ b/versioned_docs/version-1.13/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/port-forwarding.md
+++ b/versioned_docs/version-1.13/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.13/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.13/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.13/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.13/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.13/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.13/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.13/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.13/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.13/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/network.md
@@ -7,7 +7,7 @@ title: Network (macOS)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`
 

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.13/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.13/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.13/ui/preferences/wsl/network.md
@@ -7,7 +7,7 @@ title: Network (Windows)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/versioned_docs/version-1.13/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.13/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.13/ui/snapshots.md
+++ b/versioned_docs/version-1.13/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.13/ui/troubleshooting.md
+++ b/versioned_docs/version-1.13/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.13/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/getting-started/deployment.md
+++ b/versioned_docs/version-1.14/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/getting-started/introduction.md
+++ b/versioned_docs/version-1.14/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.14/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.14/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/containers.md
+++ b/versioned_docs/version-1.14/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/diagnostics.md
+++ b/versioned_docs/version-1.14/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/extensions.md
+++ b/versioned_docs/version-1.14/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.14/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/general.md
+++ b/versioned_docs/version-1.14/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/images.md
+++ b/versioned_docs/version-1.14/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/port-forwarding.md
+++ b/versioned_docs/version-1.14/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.14/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.14/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.14/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.14/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.14/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.14/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.14/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.14/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.14/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/network.md
@@ -7,7 +7,7 @@ title: Network (macOS)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`
 

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.14/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.14/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.14/ui/preferences/wsl/network.md
@@ -7,7 +7,7 @@ title: Network (Windows)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/versioned_docs/version-1.14/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.14/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.14/ui/snapshots.md
+++ b/versioned_docs/version-1.14/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.14/ui/troubleshooting.md
+++ b/versioned_docs/version-1.14/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/getting-started/deployment.md
+++ b/versioned_docs/version-1.15/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/getting-started/introduction.md
+++ b/versioned_docs/version-1.15/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.15/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.15/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/containers.md
+++ b/versioned_docs/version-1.15/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/diagnostics.md
+++ b/versioned_docs/version-1.15/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/extensions.md
+++ b/versioned_docs/version-1.15/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.15/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/general.md
+++ b/versioned_docs/version-1.15/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/images.md
+++ b/versioned_docs/version-1.15/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/port-forwarding.md
+++ b/versioned_docs/version-1.15/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.15/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.15/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.15/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.15/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.15/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.15/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.15/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.15/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.15/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.15/ui/snapshots.md
+++ b/versioned_docs/version-1.15/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.15/ui/troubleshooting.md
+++ b/versioned_docs/version-1.15/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.15/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/getting-started/deployment.md
+++ b/versioned_docs/version-1.16/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/getting-started/introduction.md
+++ b/versioned_docs/version-1.16/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.16/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.16/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/containers.md
+++ b/versioned_docs/version-1.16/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/diagnostics.md
+++ b/versioned_docs/version-1.16/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/extensions.md
+++ b/versioned_docs/version-1.16/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.16/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/general.md
+++ b/versioned_docs/version-1.16/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/images.md
+++ b/versioned_docs/version-1.16/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/port-forwarding.md
+++ b/versioned_docs/version-1.16/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.16/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.16/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.16/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.16/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.16/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.16/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.16/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.16/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.16/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.16/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.16/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.16/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.16/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.16/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.16/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.16/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.16/ui/snapshots.md
+++ b/versioned_docs/version-1.16/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.16/ui/troubleshooting.md
+++ b/versioned_docs/version-1.16/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.16/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/getting-started/deployment.md
+++ b/versioned_docs/version-1.17/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/getting-started/introduction.md
+++ b/versioned_docs/version-1.17/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.17/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.17/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/containers.md
+++ b/versioned_docs/version-1.17/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/diagnostics.md
+++ b/versioned_docs/version-1.17/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/extensions.md
+++ b/versioned_docs/version-1.17/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.17/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/general.md
+++ b/versioned_docs/version-1.17/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/images.md
+++ b/versioned_docs/version-1.17/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/port-forwarding.md
+++ b/versioned_docs/version-1.17/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.17/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.17/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.17/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.17/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.17/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.17/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.17/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.17/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.17/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.17/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.17/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.17/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.17/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.17/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.17/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.17/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.17/ui/snapshots.md
+++ b/versioned_docs/version-1.17/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.17/ui/troubleshooting.md
+++ b/versioned_docs/version-1.17/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.17/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/getting-started/deployment.md
+++ b/versioned_docs/version-1.18/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/getting-started/introduction.md
+++ b/versioned_docs/version-1.18/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.18/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.18/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/containers.md
+++ b/versioned_docs/version-1.18/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/diagnostics.md
+++ b/versioned_docs/version-1.18/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/extensions.md
+++ b/versioned_docs/version-1.18/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/general.md
+++ b/versioned_docs/version-1.18/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/images.md
+++ b/versioned_docs/version-1.18/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/port-forwarding.md
+++ b/versioned_docs/version-1.18/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.18/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.18/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.18/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.18/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.18/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.18/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.18/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.18/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.18/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.18/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-1.18/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.18/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.18/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.18/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.18/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.18/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.18/ui/snapshots.md
+++ b/versioned_docs/version-1.18/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.18/ui/troubleshooting.md
+++ b/versioned_docs/version-1.18/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/diagnostics.md
+++ b/versioned_docs/version-1.7/ui/diagnostics.md
@@ -22,17 +22,17 @@ On this tab you can mute/unmute individual checks if you have a non-standard set
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/general.md
+++ b/versioned_docs/version-1.7/ui/general.md
@@ -16,17 +16,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/images.md
+++ b/versioned_docs/version-1.7/ui/images.md
@@ -18,17 +18,17 @@ To manage your images using nerdctl instead, refer to the [Images](../tutorials/
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/port-forwarding.md
+++ b/versioned_docs/version-1.7/ui/port-forwarding.md
@@ -21,17 +21,17 @@ To forward a port:
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/preferences/application.md
+++ b/versioned_docs/version-1.7/ui/preferences/application.md
@@ -18,7 +18,7 @@ When an update is available, users are provided a notification and the release n
 
 This option allows Rancher Desktop to collect information on how you interact with the Rancher Desktop application. Information such as what workloads you run are not collected.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_application.png)
+![](rd-versioned-asset://preferences/Windows_application.png)
 
 </TabItem>
 <TabItem value="macOS">
@@ -37,7 +37,7 @@ When an update is available, users are provided a notification and the release n
 
 This option allows Rancher Desktop to collect information on how you interact with the Rancher Desktop application. Information such as what workloads you run are not collected.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 ### Environment
 
@@ -52,7 +52,7 @@ There are two options for doing this:
 - **Automatic**: `PATH` management will add `~/.rd/bin` to your `PATH` by modifying your shell .rc files for you.
 - **Manual**: `PATH` management does not change anything - in this mode, you must add `~/.rd/bin` to your `PATH` yourself.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 </TabItem>
 <TabItem value="Linux">
@@ -71,7 +71,7 @@ When an update is available, users are provided a notification and the release n
 
 This option allows Rancher Desktop to collect information on how you interact with the Rancher Desktop application. Information such as what workloads you run are not collected.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 ### Environment
 
@@ -86,7 +86,7 @@ There are two options for doing this:
 - **Automatic**: `PATH` management will add `~/.rd/bin` to your `PATH` by modifying your shell .rc files for you.
 - **Manual**: `PATH` management does not change anything - in this mode, you must add `~/.rd/bin` to your `PATH` yourself.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/preferences/container-engine.md
+++ b/versioned_docs/version-1.7/ui/preferences/container-engine.md
@@ -18,17 +18,17 @@ When switching to a different container runtime:
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>
@@ -44,17 +44,17 @@ You can use the **+** and **-** buttons to add/remove image name patterns.
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.7/ui/preferences/kubernetes.md
@@ -46,17 +46,17 @@ Disabling Traefik will not delete existing resources.
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/preferences/virtual-machine.md
+++ b/versioned_docs/version-1.7/ui/preferences/virtual-machine.md
@@ -18,12 +18,12 @@ The number of CPUs to allocate to Rancher Desktop. The selectable range is based
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/macOS_virtualMachine.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Linux_virtualMachine.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.7/ui/preferences/wsl.md
+++ b/versioned_docs/version-1.7/ui/preferences/wsl.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 The option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/preferences/Windows_wsl.png)
+![](rd-versioned-asset://preferences/Windows_wsl.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.7/ui/troubleshooting.md
+++ b/versioned_docs/version-1.7/ui/troubleshooting.md
@@ -43,17 +43,17 @@ To perform a factory reset:
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.7/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/diagnostics.md
+++ b/versioned_docs/version-1.8/ui/diagnostics.md
@@ -18,17 +18,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/general.md
+++ b/versioned_docs/version-1.8/ui/general.md
@@ -16,17 +16,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/images.md
+++ b/versioned_docs/version-1.8/ui/images.md
@@ -18,17 +18,17 @@ To manage your images using nerdctl instead, refer to the [Images](../tutorials/
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/port-forwarding.md
+++ b/versioned_docs/version-1.8/ui/port-forwarding.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/preferences/application.md
+++ b/versioned_docs/version-1.8/ui/preferences/application.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -27,7 +27,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -44,7 +44,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -68,7 +68,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -89,7 +89,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -110,7 +110,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 
@@ -138,7 +138,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -154,7 +154,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.8/ui/preferences/container-engine.md
+++ b/versioned_docs/version-1.8/ui/preferences/container-engine.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>
@@ -41,17 +41,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.8/ui/preferences/kubernetes.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/preferences/virtual-machine.md
+++ b/versioned_docs/version-1.8/ui/preferences/virtual-machine.md
@@ -10,12 +10,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/macOS_virtualMachine.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Linux_virtualMachine.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.8/ui/preferences/wsl.md
+++ b/versioned_docs/version-1.8/ui/preferences/wsl.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 The option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/preferences/Windows_wsl.png)
+![](rd-versioned-asset://preferences/Windows_wsl.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.8/ui/troubleshooting.md
+++ b/versioned_docs/version-1.8/ui/troubleshooting.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.8/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/getting-started/deployment.md
+++ b/versioned_docs/version-1.9/getting-started/deployment.md
@@ -64,23 +64,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/getting-started/introduction.md
+++ b/versioned_docs/version-1.9/getting-started/introduction.md
@@ -13,7 +13,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.10/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.9/how-to-guides/installing-uninstalling-extensions.md
@@ -23,7 +23,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -46,7 +46,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -69,7 +69,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -102,12 +102,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -136,12 +136,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -170,12 +170,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/diagnostics.md
+++ b/versioned_docs/version-1.9/ui/diagnostics.md
@@ -18,17 +18,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/extensions.md
+++ b/versioned_docs/version-1.9/ui/extensions.md
@@ -18,17 +18,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -44,17 +44,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.9/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/general.md
+++ b/versioned_docs/version-1.9/ui/general.md
@@ -16,17 +16,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/images.md
+++ b/versioned_docs/version-1.9/ui/images.md
@@ -18,17 +18,17 @@ To manage your images using nerdctl instead, refer to the [Images](../tutorials/
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/port-forwarding.md
+++ b/versioned_docs/version-1.9/ui/port-forwarding.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.9/ui/preferences/application/behavior.md
@@ -12,7 +12,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -37,7 +37,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -62,7 +62,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-1.9/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.9/ui/preferences/application/environment.md
@@ -12,7 +12,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -28,7 +28,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-1.9/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.9/ui/preferences/application/general.md
@@ -12,7 +12,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -25,7 +25,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -42,7 +42,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-1.9/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.9/ui/preferences/container-engine/allowed-images.md
@@ -12,17 +12,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.9/ui/preferences/container-engine/general.md
@@ -12,17 +12,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.9/ui/preferences/kubernetes.md
@@ -10,17 +10,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.9/ui/preferences/virtual-machine/emulation.md
@@ -3,13 +3,13 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 ### QEMU
 
 The "[QEMU](https://www.qemu.org/documentation/)" option is enabled by default and is used to run a guest operating system.
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabEmulation_vz.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)
 
 ### VZ
 

--- a/versioned_docs/version-1.9/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.9/ui/preferences/virtual-machine/hardware.md
@@ -10,12 +10,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.9/ui/preferences/virtual-machine/network.md
@@ -3,7 +3,7 @@ sidebar_label: Network
 title: Network (macOS)
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable socket-vmnet
 

--- a/versioned_docs/version-1.9/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.9/ui/preferences/virtual-machine/volumes.md
@@ -14,12 +14,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -31,12 +31,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -66,7 +66,7 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_virtiofs.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.9/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.9/ui/preferences/wsl/integrations.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-1.9/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.9/ui/preferences/wsl/network.md
@@ -3,7 +3,7 @@ sidebar_label: Network
 title: Network (Windows)
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/versioned_docs/version-1.9/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.9/ui/preferences/wsl/proxy.md
@@ -3,7 +3,7 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-1.9/ui/troubleshooting.md
+++ b/versioned_docs/version-1.9/ui/troubleshooting.md
@@ -14,17 +14,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.9/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/getting-started/deployment.md
+++ b/versioned_docs/version-latest/getting-started/deployment.md
@@ -63,23 +63,23 @@ For versions `1.9` and later of Rancher Desktop, all preferences values can be l
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes_lockedFields.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages_lockedFields.png)
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_kubernetes_lockedFields.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes_lockedFields.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/getting-started/introduction.md
+++ b/versioned_docs/version-latest/getting-started/introduction.md
@@ -11,7 +11,7 @@ import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/getting-started/introduction_preferences_tabKubernetes.png)
+![](rd-versioned-asset://getting-started/introduction_preferences_tabKubernetes.png)
 
 _The above image shows Kubernetes settings on Mac on the left and Windows on the right._
 

--- a/versioned_docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
@@ -25,7 +25,7 @@ There are two ways in which you can install extensions, a method using the UI an
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png) 
+![](rd-versioned-asset://ui-main/Windows_Extensions.png) 
 
 #### Using the Command Line
 
@@ -48,7 +48,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 #### Using the Command Line
 
@@ -71,7 +71,7 @@ rdctl extension install <image-id>:<tag>
 
 Click **Extensions** from the main UI to navigate to the **Catalog** tab. Here you can search through extensions available for use which can be downloaded and installed using the **Install** button.
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 #### Using the Command Line
 
@@ -104,12 +104,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -138,12 +138,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>
@@ -172,12 +172,12 @@ Click **Extensions** from the main UI to navigate to the **Catalog** tab. On thi
 <Tabs>
 <TabItem value="Catalog">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 <TabItem value="Installed">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/containers.md
+++ b/versioned_docs/version-latest/ui/containers.md
@@ -13,17 +13,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Windows_Containers.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/macOS_Containers.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Containers_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Containers.png)
+![Containers_Example](rd-versioned-asset://ui-main/Linux_Containers.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/diagnostics.md
+++ b/versioned_docs/version-latest/ui/diagnostics.md
@@ -16,17 +16,17 @@ The **Diagnostics** feature runs several checks in the background to detect comm
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Windows_Diagnostics.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Diagnostics.png)
+![](rd-versioned-asset://ui-main/macOS_Diagnostics.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Diagnostics.png)
+![](rd-versioned-asset://ui-main/Linux_Diagnostics.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/extensions.md
+++ b/versioned_docs/version-latest/ui/extensions.md
@@ -16,17 +16,17 @@ The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensio
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions.png)
 
 </TabItem>
 </Tabs>
@@ -42,17 +42,17 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Windows_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Windows_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/macOS_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/macOS_Extensions-Installed.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.us-east-1.amazonaws.com/desktop/v1.18/ui-main/Linux_Extensions-Installed.png)
+![](rd-versioned-asset://ui-main/Linux_Extensions-Installed.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/general.md
+++ b/versioned_docs/version-latest/ui/general.md
@@ -14,17 +14,17 @@ The **General** tab provides information on communication channels where users c
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_General.png)
+![](rd-versioned-asset://ui-main/Windows_General.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_General.png)
+![](rd-versioned-asset://ui-main/macOS_General.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_General.png)
+![](rd-versioned-asset://ui-main/Linux_General.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/images.md
+++ b/versioned_docs/version-latest/ui/images.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Images.png)
+![](rd-versioned-asset://ui-main/Windows_Images.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Images.png)
+![](rd-versioned-asset://ui-main/macOS_Images.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Images.png)
+![](rd-versioned-asset://ui-main/Linux_Images.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/port-forwarding.md
+++ b/versioned_docs/version-latest/ui/port-forwarding.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Windows_PortForwarding.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_PortForwarding.png)
+![](rd-versioned-asset://ui-main/macOS_PortForwarding.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_PortForwarding.png)
+![](rd-versioned-asset://ui-main/Linux_PortForwarding.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-latest/ui/preferences/application/behavior.md
@@ -14,7 +14,7 @@ Allows for configuration of application behavior upon startup, background proces
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Windows_application_tabBehavior.png)
 
 #### Startup
 
@@ -39,7 +39,7 @@ Rancher Desktop shows the application status with a notification icon. The conte
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/macOS_application_tabBehavior.png)
 
 #### Startup
 
@@ -64,7 +64,7 @@ Rancher Desktop shows the application status with a notification icon in the men
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabBehavior.png)
+![](rd-versioned-asset://preferences/Linux_application_tabBehavior.png)
 
 #### Startup
 

--- a/versioned_docs/version-latest/ui/preferences/application/environment.md
+++ b/versioned_docs/version-latest/ui/preferences/application/environment.md
@@ -14,7 +14,7 @@ Allows for configuration of the `$PATH` variable in the users shell in order to 
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/macOS_application_tabEnvironment.png)
 
 #### Configure PATH
 
@@ -30,7 +30,7 @@ There are two options for doing this:
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabEnvironment.png)
+![](rd-versioned-asset://preferences/Linux_application_tabEnvironment.png)
 
 #### Configure PATH
 

--- a/versioned_docs/version-latest/ui/preferences/application/general.md
+++ b/versioned_docs/version-latest/ui/preferences/application/general.md
@@ -14,7 +14,7 @@ Allows for enablement of automatic updates, as well as an optional field to allo
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_application_tabGeneral.png)
 
 #### Automatic Updates
 
@@ -29,7 +29,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_application_tabGeneral.png)
 
 #### Administrative Access
 
@@ -48,7 +48,7 @@ This option allows Rancher Desktop to collect information on how you interact wi
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_application_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_application_tabGeneral.png)
 
 #### Administrative Access
 

--- a/versioned_docs/version-latest/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-latest/ui/preferences/container-engine/allowed-images.md
@@ -14,17 +14,17 @@ The `Allowed Images` tab lets you control which registry artifacts you can acces
 <Tabs groupId="os">
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabAllowedImages.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabAllowedImages.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-latest/ui/preferences/container-engine/general.md
@@ -14,17 +14,17 @@ Set the [container runtime] for Rancher Desktop. Users have the option of [conta
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Windows_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/macOS_containerEngine_tabGeneral.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_containerEngine_tabGeneral.png)
+![](rd-versioned-asset://preferences/Linux_containerEngine_tabGeneral.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-latest/ui/preferences/kubernetes.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_kubernetes.png)
+![](rd-versioned-asset://preferences/Windows_kubernetes.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_kubernetes.png)
+![](rd-versioned-asset://preferences/macOS_kubernetes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_kubernetes.png)
+![](rd-versioned-asset://preferences/Linux_kubernetes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/emulation.md
@@ -9,13 +9,13 @@ title: Emulation (macOS)
 
 ### QEMU
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default and turns on a guest operating system. You can switch the virtual machine type after the first run.
 
 ### VZ
 
- ![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabEmulation.png)
+ ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
 :::caution warning
 

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/hardware.md
@@ -12,12 +12,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabHardware.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabHardware.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabHardware.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/network.md
@@ -7,7 +7,7 @@ title: Network (macOS)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/macOS_virtualMachine_tabNetwork.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`
 

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
@@ -16,12 +16,12 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>
@@ -33,12 +33,12 @@ Users can enable the "[reverse-sshfs](https://github.com/lima-vm/lima/blob/maste
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes_9P.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes_9P.png)
 
 </TabItem>
 </Tabs>
@@ -68,12 +68,12 @@ Users can select a supported security model with options being `[passthrough, ma
 <Tabs groupId="os">
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/macOS_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/macOS_virtualMachine_tabVolumes.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Linux_virtualMachine_tabVolumes.png)
+![](rd-versioned-asset://preferences/Linux_virtualMachine_tabVolumes.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/integrations.md
@@ -9,7 +9,7 @@ title: Integrations
 
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_wsl_tabIntegrations.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)
 
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 

--- a/versioned_docs/version-latest/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/network.md
@@ -7,7 +7,7 @@ title: Network (Windows)
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.14/preferences/Windows_wsl_tabNetwork.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel
 

--- a/versioned_docs/version-latest/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/proxy.md
@@ -7,7 +7,7 @@ title: Proxy
   <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
 </head>
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/preferences/Windows_wsl_tabProxy.png)
+![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy
 

--- a/versioned_docs/version-latest/ui/snapshots.md
+++ b/versioned_docs/version-latest/ui/snapshots.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Windows_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/macOS_Snapshots-List.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![Snapshots_Example](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Snapshots-List.png)
+![Snapshots_Example](rd-versioned-asset://ui-main/Linux_Snapshots-List.png)
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-latest/ui/troubleshooting.md
+++ b/versioned_docs/version-latest/ui/troubleshooting.md
@@ -12,17 +12,17 @@ import TabsConstants from '@site/core/TabsConstants';
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Windows_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Windows_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="macOS">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/macOS_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/macOS_Troubleshooting.png)
 
 </TabItem>
 <TabItem value="Linux">
 
-![](https://suse-rancher-media.s3.amazonaws.com/desktop/v1.18/ui-main/Linux_Troubleshooting.png)
+![](rd-versioned-asset://ui-main/Linux_Troubleshooting.png)
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
This implements a remark plugin that scans for all images using URLs starting with `rd-versioned-asset://` and replace it with a versioned S3 URL in the form of `https://suse-rancher-media.s3.amazonaws.com/desktop/v1.23` so that we don't need to manually change the version every release (and potentially lead to errors).

For `latest` and `next`, we use the largest version listed in `versions.json`.

The generated files should look identical to before the change.

The PR is in two commits: one to write the plugin, and the second with mechanical changes to the markdown files to use it.