### PR TITLE
Clean up CI test deployment workflow

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,19 +4,28 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   test-deploy:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
         with:
-          node-version: 18.x
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Check links
-        run: yarn run remark --use remark-validate-links --use remark-lint-no-dead-urls=skipUrlPatterns:[\'https://rancher.rd.localhost\',\'https://openai.com/api/\',\'https://docs.openwebui.com/\',\'https://openwebui.com/\'],skipLocalhost:true --quiet --frail ./docs/ ./versioned_docs/
+        run: >-
+          yarn run remark
+          --rc-path .remarkrc.yaml
+          --frail
+          ./docs/
+          ./versioned_docs/
       - name: Test build
         run: yarn build

--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -9,4 +9,6 @@ plugins:
     - https://openai.com/api/
     - https://docs.openwebui.com/
     - https://openwebui.com/
+    - https://download.opensuse.org/repositories/isv:/Rancher:/stable/AppImage/rancher-desktop-latest-x86_64.AppImage
+      # Skip the AppImage download check; sometimes mirrors fall over.
     skipLocalhost: true

--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -1,0 +1,12 @@
+# This is the remark configration for testing deployments
+# (i.e. .github/workflows/test-deploy.yml)
+
+plugins:
+- remark-validate-links
+- - remark-lint-no-dead-urls
+  - skipUrlPatterns:
+    - https://rancher.rd.localhost
+    - https://openai.com/api/
+    - https://docs.openwebui.com/
+    - https://openwebui.com/
+    skipLocalhost: true


### PR DESCRIPTION
- Update NodeJS to current LTS version (whatever that is)
- Update GitHub Actions (checkout v3 → v4, setup-node v3 → v4)
- Move remark configuration to a YAML file so we can have comments and can read the expression easier
- Add the AppImage download location to ignored URLs, because sometimes we end up on a mirror with the file missing.  This should be fine because we check the file as one of the steps of our release check list.

This is in preparation for adding the URL from #708 that keeps failing for unknown reasons (but I wanted to do that in that PR instead of this one).