### PR TITLE
CI: Document dead url skip patterns

### DIFF
--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -6,9 +6,8 @@ plugins:
 - - remark-lint-no-dead-urls
   - skipUrlPatterns:
     - https://rancher.rd.localhost
-    - https://openai.com/api/
-    - https://docs.openwebui.com/
-    - https://openwebui.com/
+    - https://openai.com/api/ # CloudFlare challenge
+    - https://openwebui.com/ # CloudFlare challenge
     - https://download.opensuse.org/repositories/isv:/Rancher:/stable/AppImage/rancher-desktop-latest-x86_64.AppImage
       # Skip the AppImage download check; sometimes mirrors fall over.
     skipLocalhost: true


### PR DESCRIPTION
Both openai and openwebui have their websites behind CloudFlare; this means that the link checker will fail in CI because it is detected as scraping.  Skip them (but not docs.openwebui) because they otherwise fail.

This is a follow-up to #423 where I actually test what fails and remove the things that don't matter.