### PR TITLE
Change localdev.me to localtest.me

### DIFF
--- a/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.10/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.10/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.11/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.11/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.12/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.12/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.13/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.13/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.14/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.14/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.15/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.15/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.16/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.16/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.17/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.17/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.18/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.18/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.6/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.6/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -52,7 +52,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -61,4 +61,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.7/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.7/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -52,7 +52,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -61,4 +61,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.8/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.8/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -52,7 +52,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -61,4 +61,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.9-tech-preview/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.9-tech-preview/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -48,7 +48,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -57,4 +57,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-1.9/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.9/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -52,7 +52,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -61,4 +61,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.

--- a/versioned_docs/version-latest/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-latest/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -49,7 +49,7 @@ kubectl expose deployment demo
 5. Create an ingress resource. The following command uses a host that maps to localhost.
 
 ```
-kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=demo:80"
+kubectl create ingress demo-localhost --class=nginx --rule="demo.localtest.me/*=demo:80"
 ```
 
 6. Forward a local port to the ingress controller.
@@ -58,4 +58,4 @@ kubectl create ingress demo-localhost --class=nginx --rule="demo.localdev.me/*=d
 kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
 ```
 
-If you access http://demo.localdev.me:8080/, you should see NGINX Welcome page.
+If you access http://demo.localtest.me:8080/, you should see NGINX Welcome page.


### PR DESCRIPTION
The localdev.me seems to no longer work. localtest.me has been in operation since 2012, so hopefully will continue to be maintained.

Ref [Scott Forsyth's Blog - Introducing Testing Domain - localtest.me](https://asp-blogs.azurewebsites.net/owscott/introducing-testing-domain-localtest-me)

Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/8656