### PR TITLE
Remove links to no longer existing network preferences

### DIFF
--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/network.md
@@ -4,7 +4,6 @@ title: Network (macOS)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)

--- a/versioned_docs/version-1.10/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.10/ui/preferences/wsl/network.md
@@ -4,7 +4,6 @@ title: Network (Windows)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/network.md
@@ -4,7 +4,6 @@ title: Network (macOS)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)

--- a/versioned_docs/version-1.11/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.11/ui/preferences/wsl/network.md
@@ -4,7 +4,6 @@ title: Network (Windows)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/network.md
@@ -4,7 +4,6 @@ title: Network (macOS)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)

--- a/versioned_docs/version-1.12/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/network.md
@@ -4,7 +4,6 @@ title: Network (Windows)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/network.md
@@ -4,7 +4,6 @@ title: Network (macOS)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)

--- a/versioned_docs/version-1.13/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.13/ui/preferences/wsl/network.md
@@ -4,7 +4,6 @@ title: Network (Windows)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/network.md
@@ -4,7 +4,6 @@ title: Network (macOS)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)

--- a/versioned_docs/version-1.14/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.14/ui/preferences/wsl/network.md
@@ -4,7 +4,6 @@ title: Network (Windows)
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/network"/>
 </head>
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)


### PR DESCRIPTION
```shell
find versioned_docs -name 'network.md' -exec perl -n -i -e 'print unless m#canonical.*/network"#' {} \;
```

The `network.md` files were removed in #435.

All to appease the mighty link checker.