### PR TITLE
Remove experimental banner in VZ emulation

### DIFF
--- a/docs/ui/preferences/virtual-machine/emulation.md
+++ b/docs/ui/preferences/virtual-machine/emulation.md
@@ -17,12 +17,6 @@ The [**QEMU**](https://www.qemu.org/documentation/) option is enabled by default
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)
 
-:::caution warning
-
-This is an *experimental* setting. The setting is available for ARM machines on  macOS 13.3 or later, and Intel machines on macOS 13.0 or later.
-
-:::
-
 You can also enable the **VZ** option to use the native macOS [Virtualization.Framework](https://developer.apple.com/documentation/virtualization) for running a guest machine.
 
 The suboption **VZ option** can also be enabled if using **VZ** as your virtual machine type. The suboption enables [Rosetta support](https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta) and allows users to run applications that contain x86_64 instructions on Apple hardware.


### PR DESCRIPTION
As of 19.0, VZ emulation is no longer experimental. This change removes the admonition from the docs.

Ref: https://github.com/rancher-sandbox/rancher-desktop/releases/tag/v1.19.0

