### PR TITLE
Rewrite testcontainers guide with simplified configuration

### DIFF
--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -23,13 +23,13 @@ The **containerd** runtime does not expose a Docker-compatible API and will not 
 
 ### For the example below
 
-- [Java (JDK)](https://formulae.brew.sh/formula/openjdk): `brew install openjdk`
-- [Apache Maven](https://maven.apache.org/install.html): `brew install maven`
+- [Java (JDK)](https://www.java.com/)
+- [Apache Maven](https://maven.apache.org/install.html)
 
 ## Configuration
 
 <Tabs groupId="os">
-<TabItem value="macOS" label="macOS">
+<TabItem value="macOS-Linux" label="macOS & Linux">
 
 Rancher Desktop runs containers inside a virtual machine. Testcontainers needs three environment variables to locate the Docker socket and connect to container ports inside the VM:
 
@@ -39,43 +39,46 @@ export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
 export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
 ```
 
+Add these lines to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to set them automatically.
+
 **What each variable does:**
 
 - `DOCKER_HOST` tells Testcontainers where to find the Docker socket. Rancher Desktop places it at `~/.rd/docker.sock` rather than the default `/var/run/docker.sock`.
 - `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` tells Testcontainers which socket path to mount into helper containers (like Ryuk). Inside the VM the socket is at the standard `/var/run/docker.sock` path.
 - `TESTCONTAINERS_HOST_OVERRIDE` tells Testcontainers which host to connect to for mapped ports. The `rdctl info --field ip-address` command returns the VM's routable IP address.
 
-Add these lines to your `~/.zshrc` (or `~/.bashrc`) to set them automatically.
-
 :::note
 These variables work with all virtual machine types (VZ and QEMU), with or without Rosetta support, and regardless of whether administrative access is enabled.
 :::
 
 </TabItem>
-<TabItem value="Linux" label="Linux">
-
-On Linux, Rancher Desktop also runs containers inside a virtual machine. Set the same three environment variables as on macOS:
-
-```bash
-export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
-export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
-```
-
-Add these lines to your `~/.bashrc` (or `~/.zshrc`) to set them automatically.
-
-</TabItem>
 <TabItem value="Windows" label="Windows">
 
-On Windows, run Testcontainers from within a WSL2 distribution where Rancher Desktop integration is enabled. Set the same three environment variables in your WSL2 shell profile:
+On Windows, Testcontainers works both from native Win32 programs and from inside WSL2 distributions.
 
-```bash
-export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
-export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
+**Native Win32 (PowerShell, CMD, Git Bash):**
+
+Tell Testcontainers to connect via the Windows named pipe. In PowerShell:
+
+```powershell
+$env:DOCKER_HOST = "npipe:////./pipe/docker_engine"
 ```
 
-Add these lines to your `~/.bashrc` to set them automatically.
+In Git Bash / MSYS2:
+
+```bash
+export DOCKER_HOST="npipe:////./pipe/docker_engine"
+```
+
+No other environment variables are needed. Container ports are accessible on `localhost`.
+
+**WSL2:**
+
+No environment variables are needed when running from a WSL2 distribution where Rancher Desktop integration is enabled. The Docker socket is at `/var/run/docker.sock` (the default location) and container ports are accessible on `localhost`.
+
+:::note
+The `rdctl` Linux binary does not work inside WSL2. Use `rdctl.exe` instead if you need to run `rdctl` commands from your WSL2 shell.
+:::
 
 </TabItem>
 </Tabs>
@@ -90,6 +93,10 @@ $ cd testcontainers-java-repro
 $ mvn verify
 ```
 
+:::tip
+If you see `"client version 1.32 is too old"`, the example repository's Testcontainers version needs to be updated. Edit `pom.xml` and change the `testcontainers-bom` version to `2.0.4` (or later), then run `mvn verify` again. See [Troubleshooting](#client-version-132-is-too-old) for details.
+:::
+
 A successful run produces output like this:
 
 ```
@@ -102,7 +109,9 @@ A successful run produces output like this:
 
 ### "Could not find a valid Docker environment"
 
-Testcontainers cannot connect to the Docker daemon. Verify that `DOCKER_HOST` is set and that the socket file exists:
+Testcontainers cannot connect to the Docker daemon.
+
+On macOS and Linux, verify that `DOCKER_HOST` is set and that the socket file exists:
 
 ```console
 $ echo $DOCKER_HOST
@@ -112,11 +121,24 @@ $ ls -la ~/.rd/docker.sock
 srw-------  1 yourname  staff  0 Jan  1 00:00 /Users/yourname/.rd/docker.sock
 ```
 
+On Windows (native), verify that `DOCKER_HOST` is set to `npipe:////./pipe/docker_engine`.
+
+On Windows (WSL2), verify the default socket exists:
+
+```console
+$ ls -la /var/run/docker.sock
+srwxrwxrwx  1 root  root  0 Jan  1 00:00 /var/run/docker.sock
+```
+
 If the socket file is missing, check that Rancher Desktop is running and that the container engine is set to **moby (dockerd)**.
+
+### "client version 1.32 is too old"
+
+The Docker Java client library bundled with older Testcontainers versions defaults to API version 1.32, which is below the minimum required by current Docker Engine versions. Upgrade your project's Testcontainers dependency to version 2.0 or later.
 
 ### "Connection refused" on mapped ports
 
-Testcontainers connects to `localhost` by default, but container ports are exposed on the VM's IP address. Verify that `TESTCONTAINERS_HOST_OVERRIDE` is set:
+On macOS and Linux, container ports are exposed on the VM's IP address, not `localhost`. Verify that `TESTCONTAINERS_HOST_OVERRIDE` is set:
 
 ```console
 $ echo $TESTCONTAINERS_HOST_OVERRIDE
@@ -125,6 +147,8 @@ $ echo $TESTCONTAINERS_HOST_OVERRIDE
 
 If the variable is empty, run `rdctl info --field ip-address` to confirm Rancher Desktop is running and returning an IP address.
 
+On Windows, `TESTCONTAINERS_HOST_OVERRIDE` should **not** be set. Container ports are accessible on `localhost` by default.
+
 ### "Can not connect to Ryuk"
 
-The Ryuk helper container needs to reach the Docker socket inside the VM. Verify that `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` is set to `/var/run/docker.sock`.
+On macOS and Linux, the Ryuk helper container needs to reach the Docker socket inside the VM. Verify that `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` is set to `/var/run/docker.sock`.

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -87,17 +87,20 @@ The `rdctl` Linux binary does not work inside WSL2. Use `rdctl.exe` instead if y
 
 ## Running the example
 
-Clone the [Testcontainers Java example repository](https://github.com/testcontainers/testcontainers-java-repro) and run its tests:
+Clone the [Testcontainers Java example repository](https://github.com/testcontainers/testcontainers-java-repro), update the Testcontainers version, and run the tests:
 
-```console
-$ git clone https://github.com/testcontainers/testcontainers-java-repro
-$ cd testcontainers-java-repro
-$ mvn verify
-```
+1. Clone the repository:
+   ```console
+   $ git clone https://github.com/testcontainers/testcontainers-java-repro
+   $ cd testcontainers-java-repro
+   ```
 
-:::tip
-If you see `"client version 1.32 is too old"`, the example repository's Testcontainers version needs to be updated. Edit `pom.xml` and change the `testcontainers-bom` version to `2.0.4` (or later), then run `mvn verify` again. See [Troubleshooting](#client-version-132-is-too-old) for details.
-:::
+2. Edit `pom.xml` and change the `testcontainers-bom` version to `2.0.4` (or later). The repository ships with an older version that is incompatible with current Docker Engine releases.
+
+3. Run the tests:
+   ```console
+   $ mvn verify
+   ```
 
 A successful run produces output like this:
 

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -1,120 +1,130 @@
 ---
-title: Using Testcontainers on Rancher Desktop
+title: Using Testcontainers with Rancher Desktop
 ---
 
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
 </head>
 
-import TabsConstants from '@site/core/TabsConstants';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.
+[Testcontainers](https://testcontainers.com/) lets you run throwaway containers for integration testing. This guide explains how to configure Rancher Desktop to work with Testcontainers and includes a working example you can try yourself.
 
-### Prerequisites
+## Prerequisites
 
-[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled for machines on Apple Silicon. The setting can be disabled via the **Preferences > Kubernetes** dialog, or by using the `rdctl` command below:
+Testcontainers requires the Docker API, so you must select **moby (dockerd)** as the container engine. You can change this in **Preferences > Container Engine** or with `rdctl`:
 
-```bash
-rdctl set --kubernetes-enabled=false
+```console
+$ rdctl set --container-engine.name=moby
 ```
 
- Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+The **containerd** runtime does not expose a Docker-compatible API and will not work with Testcontainers.
 
-<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
-<TabItem value="Linux">
+### For the example below
 
-You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+- [Java (JDK)](https://formulae.brew.sh/formula/openjdk): `brew install openjdk`
+- [Apache Maven](https://maven.apache.org/install.html): `brew install maven`
 
-After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
-
-```bash
-mvn verify
-```
-
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
-
-</TabItem>
-<TabItem value="macOS">
-
-You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+## Configuration
 
 <Tabs groupId="os">
-<TabItem value="Apple Silicon">
+<TabItem value="macOS" label="macOS">
 
-Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
-
-#### [QEMU](../ui/preferences/virtual-machine/emulation.md#qemu)
-
-<details>
-<summary>Workaround Summary</summary>
-
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
-
-Next, export the virtual machine port explicitly using the command below:
+Rancher Desktop runs containers inside a virtual machine. Testcontainers needs three environment variables to locate the Docker socket and connect to container ports inside the VM:
 
 ```bash
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {sub("/.*",""); print $2}')
-```
-
-</details>
-
-#### [VZ](../ui/preferences/virtual-machine/emulation.md#vz)
-
-<details>
-<summary>Workaround Summary</summary>
-
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
-
-Next, export the virtual machine port explicitly using the command below:
-
-```bash
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
-```
-
-For `VZ` virtual machines, you can also use Testcontainers without the need for administrative access by exporting the settings below:
-
-```bash
-export DOCKER_HOST=unix://$HOME/.rd/docker.sock
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
 export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
 ```
 
-</details>
+**What each variable does:**
 
-After the respective virtual machine settings have been applied, and the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+- `DOCKER_HOST` tells Testcontainers where to find the Docker socket. Rancher Desktop places it at `~/.rd/docker.sock` rather than the default `/var/run/docker.sock`.
+- `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` tells Testcontainers which socket path to mount into helper containers (like Ryuk). Inside the VM the socket is at the standard `/var/run/docker.sock` path.
+- `TESTCONTAINERS_HOST_OVERRIDE` tells Testcontainers which host to connect to for mapped ports. The `rdctl info --field ip-address` command returns the VM's routable IP address.
 
-```shell
-mvn verify
-```
+Add these lines to your `~/.zshrc` (or `~/.bashrc`) to set them automatically.
 
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+:::note
+These variables work with all virtual machine types (VZ and QEMU), with or without Rosetta support, and regardless of whether administrative access is enabled.
+:::
 
 </TabItem>
-<TabItem value="Intel">
+<TabItem value="Linux" label="Linux">
 
-After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+On Linux, Rancher Desktop also runs containers inside a virtual machine. Set the same three environment variables as on macOS:
 
-```shell
-mvn verify
+```bash
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
+export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
 ```
 
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+Add these lines to your `~/.bashrc` (or `~/.zshrc`) to set them automatically.
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+On Windows, run Testcontainers from within a WSL2 distribution where Rancher Desktop integration is enabled. Set the same three environment variables in your WSL2 shell profile:
+
+```bash
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
+export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
+```
+
+Add these lines to your `~/.bashrc` to set them automatically.
 
 </TabItem>
 </Tabs>
 
-</TabItem>
-<TabItem value="Windows">
+## Running the example
 
-You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+Clone the [Testcontainers Java example repository](https://github.com/testcontainers/testcontainers-java-repro) and run its tests:
 
-After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
-
-```shell
-mvn verify
+```console
+$ git clone https://github.com/testcontainers/testcontainers-java-repro
+$ cd testcontainers-java-repro
+$ mvn verify
 ```
 
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+A successful run produces output like this:
 
-</TabItem>
-</Tabs>
+```
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+[INFO]
+[INFO] BUILD SUCCESS
+```
+
+## Troubleshooting
+
+### "Could not find a valid Docker environment"
+
+Testcontainers cannot connect to the Docker daemon. Verify that `DOCKER_HOST` is set and that the socket file exists:
+
+```console
+$ echo $DOCKER_HOST
+unix:///Users/yourname/.rd/docker.sock
+
+$ ls -la ~/.rd/docker.sock
+srw-------  1 yourname  staff  0 Jan  1 00:00 /Users/yourname/.rd/docker.sock
+```
+
+If the socket file is missing, check that Rancher Desktop is running and that the container engine is set to **moby (dockerd)**.
+
+### "Connection refused" on mapped ports
+
+Testcontainers connects to `localhost` by default, but container ports are exposed on the VM's IP address. Verify that `TESTCONTAINERS_HOST_OVERRIDE` is set:
+
+```console
+$ echo $TESTCONTAINERS_HOST_OVERRIDE
+192.168.64.2
+```
+
+If the variable is empty, run `rdctl info --field ip-address` to confirm Rancher Desktop is running and returning an IP address.
+
+### "Can not connect to Ryuk"
+
+The Ryuk helper container needs to reach the Docker socket inside the VM. Verify that `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` is set to `/var/run/docker.sock`.

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -48,7 +48,9 @@ Add these lines to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to set the
 - `TESTCONTAINERS_HOST_OVERRIDE` tells Testcontainers which host to connect to for mapped ports. The `rdctl info --field ip-address` command returns the VM's routable IP address.
 
 :::note
-These variables work with all virtual machine types (VZ and QEMU), with or without Rosetta support, and regardless of whether administrative access is enabled.
+These instructions require the **VZ** virtual machine type (the default on macOS). VZ provides a routable VM IP address that Testcontainers uses to connect to container ports.
+
+**QEMU** requires [administrative access](../ui/preferences/application/general.md) to allocate a routable IP address. Without administrative access, the VM IP is not reachable from the host and Testcontainers cannot connect to containers.
 :::
 
 </TabItem>

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -23,13 +23,13 @@ The **containerd** runtime does not expose a Docker-compatible API and will not 
 
 ### For the example below
 
-- [Java (JDK)](https://formulae.brew.sh/formula/openjdk): `brew install openjdk`
-- [Apache Maven](https://maven.apache.org/install.html): `brew install maven`
+- [Java (JDK)](https://www.java.com/)
+- [Apache Maven](https://maven.apache.org/install.html)
 
 ## Configuration
 
 <Tabs groupId="os">
-<TabItem value="macOS" label="macOS">
+<TabItem value="macOS-Linux" label="macOS & Linux">
 
 Rancher Desktop runs containers inside a virtual machine. Testcontainers needs three environment variables to locate the Docker socket and connect to container ports inside the VM:
 
@@ -39,43 +39,46 @@ export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
 export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
 ```
 
+Add these lines to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to set them automatically.
+
 **What each variable does:**
 
 - `DOCKER_HOST` tells Testcontainers where to find the Docker socket. Rancher Desktop places it at `~/.rd/docker.sock` rather than the default `/var/run/docker.sock`.
 - `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` tells Testcontainers which socket path to mount into helper containers (like Ryuk). Inside the VM the socket is at the standard `/var/run/docker.sock` path.
 - `TESTCONTAINERS_HOST_OVERRIDE` tells Testcontainers which host to connect to for mapped ports. The `rdctl info --field ip-address` command returns the VM's routable IP address.
 
-Add these lines to your `~/.zshrc` (or `~/.bashrc`) to set them automatically.
-
 :::note
 These variables work with all virtual machine types (VZ and QEMU), with or without Rosetta support, and regardless of whether administrative access is enabled.
 :::
 
 </TabItem>
-<TabItem value="Linux" label="Linux">
-
-On Linux, Rancher Desktop also runs containers inside a virtual machine. Set the same three environment variables as on macOS:
-
-```bash
-export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
-export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
-```
-
-Add these lines to your `~/.bashrc` (or `~/.zshrc`) to set them automatically.
-
-</TabItem>
 <TabItem value="Windows" label="Windows">
 
-On Windows, run Testcontainers from within a WSL2 distribution where Rancher Desktop integration is enabled. Set the same three environment variables in your WSL2 shell profile:
+On Windows, Testcontainers works both from native Win32 programs and from inside WSL2 distributions.
 
-```bash
-export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
-export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
+**Native Win32 (PowerShell, CMD, Git Bash):**
+
+Tell Testcontainers to connect via the Windows named pipe. In PowerShell:
+
+```powershell
+$env:DOCKER_HOST = "npipe:////./pipe/docker_engine"
 ```
 
-Add these lines to your `~/.bashrc` to set them automatically.
+In Git Bash / MSYS2:
+
+```bash
+export DOCKER_HOST="npipe:////./pipe/docker_engine"
+```
+
+No other environment variables are needed. Container ports are accessible on `localhost`.
+
+**WSL2:**
+
+No environment variables are needed when running from a WSL2 distribution where Rancher Desktop integration is enabled. The Docker socket is at `/var/run/docker.sock` (the default location) and container ports are accessible on `localhost`.
+
+:::note
+The `rdctl` Linux binary does not work inside WSL2. Use `rdctl.exe` instead if you need to run `rdctl` commands from your WSL2 shell.
+:::
 
 </TabItem>
 </Tabs>
@@ -90,6 +93,10 @@ $ cd testcontainers-java-repro
 $ mvn verify
 ```
 
+:::tip
+If you see `"client version 1.32 is too old"`, the example repository's Testcontainers version needs to be updated. Edit `pom.xml` and change the `testcontainers-bom` version to `2.0.4` (or later), then run `mvn verify` again. See [Troubleshooting](#client-version-132-is-too-old) for details.
+:::
+
 A successful run produces output like this:
 
 ```
@@ -102,7 +109,9 @@ A successful run produces output like this:
 
 ### "Could not find a valid Docker environment"
 
-Testcontainers cannot connect to the Docker daemon. Verify that `DOCKER_HOST` is set and that the socket file exists:
+Testcontainers cannot connect to the Docker daemon.
+
+On macOS and Linux, verify that `DOCKER_HOST` is set and that the socket file exists:
 
 ```console
 $ echo $DOCKER_HOST
@@ -112,11 +121,24 @@ $ ls -la ~/.rd/docker.sock
 srw-------  1 yourname  staff  0 Jan  1 00:00 /Users/yourname/.rd/docker.sock
 ```
 
+On Windows (native), verify that `DOCKER_HOST` is set to `npipe:////./pipe/docker_engine`.
+
+On Windows (WSL2), verify the default socket exists:
+
+```console
+$ ls -la /var/run/docker.sock
+srwxrwxrwx  1 root  root  0 Jan  1 00:00 /var/run/docker.sock
+```
+
 If the socket file is missing, check that Rancher Desktop is running and that the container engine is set to **moby (dockerd)**.
+
+### "client version 1.32 is too old"
+
+The Docker Java client library bundled with older Testcontainers versions defaults to API version 1.32, which is below the minimum required by current Docker Engine versions. Upgrade your project's Testcontainers dependency to version 2.0 or later.
 
 ### "Connection refused" on mapped ports
 
-Testcontainers connects to `localhost` by default, but container ports are exposed on the VM's IP address. Verify that `TESTCONTAINERS_HOST_OVERRIDE` is set:
+On macOS and Linux, container ports are exposed on the VM's IP address, not `localhost`. Verify that `TESTCONTAINERS_HOST_OVERRIDE` is set:
 
 ```console
 $ echo $TESTCONTAINERS_HOST_OVERRIDE
@@ -125,6 +147,8 @@ $ echo $TESTCONTAINERS_HOST_OVERRIDE
 
 If the variable is empty, run `rdctl info --field ip-address` to confirm Rancher Desktop is running and returning an IP address.
 
+On Windows, `TESTCONTAINERS_HOST_OVERRIDE` should **not** be set. Container ports are accessible on `localhost` by default.
+
 ### "Can not connect to Ryuk"
 
-The Ryuk helper container needs to reach the Docker socket inside the VM. Verify that `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` is set to `/var/run/docker.sock`.
+On macOS and Linux, the Ryuk helper container needs to reach the Docker socket inside the VM. Verify that `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` is set to `/var/run/docker.sock`.

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -87,17 +87,20 @@ The `rdctl` Linux binary does not work inside WSL2. Use `rdctl.exe` instead if y
 
 ## Running the example
 
-Clone the [Testcontainers Java example repository](https://github.com/testcontainers/testcontainers-java-repro) and run its tests:
+Clone the [Testcontainers Java example repository](https://github.com/testcontainers/testcontainers-java-repro), update the Testcontainers version, and run the tests:
 
-```console
-$ git clone https://github.com/testcontainers/testcontainers-java-repro
-$ cd testcontainers-java-repro
-$ mvn verify
-```
+1. Clone the repository:
+   ```console
+   $ git clone https://github.com/testcontainers/testcontainers-java-repro
+   $ cd testcontainers-java-repro
+   ```
 
-:::tip
-If you see `"client version 1.32 is too old"`, the example repository's Testcontainers version needs to be updated. Edit `pom.xml` and change the `testcontainers-bom` version to `2.0.4` (or later), then run `mvn verify` again. See [Troubleshooting](#client-version-132-is-too-old) for details.
-:::
+2. Edit `pom.xml` and change the `testcontainers-bom` version to `2.0.4` (or later). The repository ships with an older version that is incompatible with current Docker Engine releases.
+
+3. Run the tests:
+   ```console
+   $ mvn verify
+   ```
 
 A successful run produces output like this:
 

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -1,120 +1,130 @@
 ---
-title: Using Testcontainers on Rancher Desktop
+title: Using Testcontainers with Rancher Desktop
 ---
 
 <head>
   <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
 </head>
 
-import TabsConstants from '@site/core/TabsConstants';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.
+[Testcontainers](https://testcontainers.com/) lets you run throwaway containers for integration testing. This guide explains how to configure Rancher Desktop to work with Testcontainers and includes a working example you can try yourself.
 
-### Prerequisites
+## Prerequisites
 
-[Testcontainers](https://testcontainers.com/) can only be used with the `moby (dockerd)` runtime as it requires a Docker-API compatible container runtime. Kubernetes must be disabled for machines on Apple Silicon. The setting can be disabled via the **Preferences > Kubernetes** dialog, or by using the `rdctl` command below:
+Testcontainers requires the Docker API, so you must select **moby (dockerd)** as the container engine. You can change this in **Preferences > Container Engine** or with `rdctl`:
 
-```bash
-rdctl set --kubernetes-enabled=false
+```console
+$ rdctl set --container-engine.name=moby
 ```
 
- Please also ensure that [Apache Maven](https://maven.apache.org/install.html) is installed on your machine in order to make use of the [`mvn verify`](https://maven.apache.org/run-maven/index.html) command.
+The **containerd** runtime does not expose a Docker-compatible API and will not work with Testcontainers.
 
-<Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
-<TabItem value="Linux">
+### For the example below
 
-You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+- [Java (JDK)](https://formulae.brew.sh/formula/openjdk): `brew install openjdk`
+- [Apache Maven](https://maven.apache.org/install.html): `brew install maven`
 
-After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
-
-```bash
-mvn verify
-```
-
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
-
-</TabItem>
-<TabItem value="macOS">
-
-You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+## Configuration
 
 <Tabs groupId="os">
-<TabItem value="Apple Silicon">
+<TabItem value="macOS" label="macOS">
 
-Currently, workarounds are needed for using Testcontainers on macOS M1 machines. Below are methods for using Testcontainers on either runtime, depending on administrative access.
-
-#### [QEMU](../ui/preferences/virtual-machine/emulation.md#qemu)
-
-<details>
-<summary>Workaround Summary</summary>
-
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
-
-Next, export the virtual machine port explicitly using the command below:
+Rancher Desktop runs containers inside a virtual machine. Testcontainers needs three environment variables to locate the Docker socket and connect to container ports inside the VM:
 
 ```bash
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show rd0 | awk '/inet / {sub("/.*",""); print $2}')
-```
-
-</details>
-
-#### [VZ](../ui/preferences/virtual-machine/emulation.md#vz)
-
-<details>
-<summary>Workaround Summary</summary>
-
-This runtime can be used with administrative access enabled which can be set via the [**Preferences > Application > General**](../ui/preferences/application/general.md) dialog. This will ensure that routable IP's are allocated.
-
-Next, export the virtual machine port explicitly using the command below:
-
-```bash
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
-```
-
-For `VZ` virtual machines, you can also use Testcontainers without the need for administrative access by exporting the settings below:
-
-```bash
-export DOCKER_HOST=unix://$HOME/.rd/docker.sock
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
 export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
 ```
 
-</details>
+**What each variable does:**
 
-After the respective virtual machine settings have been applied, and the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+- `DOCKER_HOST` tells Testcontainers where to find the Docker socket. Rancher Desktop places it at `~/.rd/docker.sock` rather than the default `/var/run/docker.sock`.
+- `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` tells Testcontainers which socket path to mount into helper containers (like Ryuk). Inside the VM the socket is at the standard `/var/run/docker.sock` path.
+- `TESTCONTAINERS_HOST_OVERRIDE` tells Testcontainers which host to connect to for mapped ports. The `rdctl info --field ip-address` command returns the VM's routable IP address.
 
-```shell
-mvn verify
-```
+Add these lines to your `~/.zshrc` (or `~/.bashrc`) to set them automatically.
 
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+:::note
+These variables work with all virtual machine types (VZ and QEMU), with or without Rosetta support, and regardless of whether administrative access is enabled.
+:::
 
 </TabItem>
-<TabItem value="Intel">
+<TabItem value="Linux" label="Linux">
 
-After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
+On Linux, Rancher Desktop also runs containers inside a virtual machine. Set the same three environment variables as on macOS:
 
-```shell
-mvn verify
+```bash
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
+export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
 ```
 
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+Add these lines to your `~/.bashrc` (or `~/.zshrc`) to set them automatically.
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+On Windows, run Testcontainers from within a WSL2 distribution where Rancher Desktop integration is enabled. Set the same three environment variables in your WSL2 shell profile:
+
+```bash
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
+export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl info --field ip-address)
+```
+
+Add these lines to your `~/.bashrc` to set them automatically.
 
 </TabItem>
 </Tabs>
 
-</TabItem>
-<TabItem value="Windows">
+## Running the example
 
-You can download a sample test repository in the `testcontainers-java-repro` located here: https://github.com/testcontainers/testcontainers-java-repro
+Clone the [Testcontainers Java example repository](https://github.com/testcontainers/testcontainers-java-repro) and run its tests:
 
-After the repository is downloaded, please navigate to the `testcontainers-java-repro` folder and run the command `mvn verify`.
-
-```shell
-mvn verify
+```console
+$ git clone https://github.com/testcontainers/testcontainers-java-repro
+$ cd testcontainers-java-repro
+$ mvn verify
 ```
 
-After the command has been run, you should see a `BUILD SUCCESS` with test statistics for failures, number of tests ran, skipped tests, time elapsed, and errors.
+A successful run produces output like this:
 
-</TabItem>
-</Tabs>
+```
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+[INFO]
+[INFO] BUILD SUCCESS
+```
+
+## Troubleshooting
+
+### "Could not find a valid Docker environment"
+
+Testcontainers cannot connect to the Docker daemon. Verify that `DOCKER_HOST` is set and that the socket file exists:
+
+```console
+$ echo $DOCKER_HOST
+unix:///Users/yourname/.rd/docker.sock
+
+$ ls -la ~/.rd/docker.sock
+srw-------  1 yourname  staff  0 Jan  1 00:00 /Users/yourname/.rd/docker.sock
+```
+
+If the socket file is missing, check that Rancher Desktop is running and that the container engine is set to **moby (dockerd)**.
+
+### "Connection refused" on mapped ports
+
+Testcontainers connects to `localhost` by default, but container ports are exposed on the VM's IP address. Verify that `TESTCONTAINERS_HOST_OVERRIDE` is set:
+
+```console
+$ echo $TESTCONTAINERS_HOST_OVERRIDE
+192.168.64.2
+```
+
+If the variable is empty, run `rdctl info --field ip-address` to confirm Rancher Desktop is running and returning an IP address.
+
+### "Can not connect to Ryuk"
+
+The Ryuk helper container needs to reach the Docker socket inside the VM. Verify that `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` is set to `/var/run/docker.sock`.

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -48,7 +48,9 @@ Add these lines to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to set the
 - `TESTCONTAINERS_HOST_OVERRIDE` tells Testcontainers which host to connect to for mapped ports. The `rdctl info --field ip-address` command returns the VM's routable IP address.
 
 :::note
-These variables work with all virtual machine types (VZ and QEMU), with or without Rosetta support, and regardless of whether administrative access is enabled.
+These instructions require the **VZ** virtual machine type (the default on macOS). VZ provides a routable VM IP address that Testcontainers uses to connect to container ports.
+
+**QEMU** requires [administrative access](../ui/preferences/application/general.md) to allocate a routable IP address. Without administrative access, the VM IP is not reachable from the host and Testcontainers cannot connect to containers.
 :::
 
 </TabItem>


### PR DESCRIPTION
Replace fragile VM-specific workarounds (rdctl shell ip a show rd0/vznat) with the new `rdctl info --field ip-address` command, which works across all VM types, with or without Rosetta, and without admin access.

Tested configurations on macOS (Apple Silicon):
- VZ without Rosetta, no admin access: pass
- VZ with Rosetta, no admin access: pass
- containerd runtime: fails (documented as unsupported)

All three environment variables (DOCKER_HOST,
TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE, TESTCONTAINERS_HOST_OVERRIDE) are required; the guide explains what each one does.

Also removes the incorrect claim that Kubernetes must be disabled on Apple Silicon, and adds a troubleshooting section.