### PR TITLE
Add RD_ASSET_VERSION to preview an upcoming release's assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ $ yarn start
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
+### Previewing assets for an upcoming release
+
+Image URLs that start with `rd-versioned-asset://` resolve at build time to the S3 folder for the latest released version in `versions.json`. The unversioned ("Next") docs therefore show the previous release's screenshots until a new version is published.
+
+To preview the docs against an unreleased version's assets, set `RD_ASSET_VERSION`:
+
+```
+$ RD_ASSET_VERSION=1.23 yarn start
+```
+
+This points the Next and `latest` docs at `desktop/v1.23/` on S3; the assets must already exist there. Leave the variable unset for normal builds.
+
 ### Build
 
 ```

--- a/src/remark/rd-versioned-assets.js
+++ b/src/remark/rd-versioned-assets.js
@@ -65,8 +65,13 @@ export default () => {
             }
             return bParts.length - aParts.length;
         }).pop();
+        // RD_ASSET_VERSION overrides the version used for the unversioned
+        // ("Next") and "latest" docs, so an upcoming release's assets can be
+        // previewed before versions.json is bumped. See the README.
+        const overrideVersion = process.env.RD_ASSET_VERSION;
+        const defaultVersion = overrideVersion ? `v${ overrideVersion.replace(/^v/, '') }` : `v${ maxVersion }`;
         /** @type any */
         const anyTree = tree;
-        await processNode(anyTree, vfile, `v${maxVersion}`);
+        await processNode(anyTree, vfile, defaultVersion);
     };
 };


### PR DESCRIPTION
Image URLs for the unversioned ("Next") and "latest" docs resolve to the latest released version's assets. Set RD_ASSET_VERSION to point them at another version, so you can preview an upcoming release's screenshots before versions.json is bumped.