### PR TITLE
Document the Appearance (light/dark theme) preference

### DIFF
--- a/docs/ui/preferences/application/behavior.md
+++ b/docs/ui/preferences/application/behavior.md
@@ -9,7 +9,7 @@ title: Behavior
 
 import TabsConstants from '@site/core/TabsConstants';
 
-Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.
+Allows for configuration of application behavior upon startup, background process behavior, notification icon display, and appearance.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
@@ -31,6 +31,10 @@ Rancher Desktop normally remains running in the background even when the main ap
 #### Notification Icon
 
 Rancher Desktop shows the application status with a notification icon. The context menu of the icon provides more status information and provides quick access to other functionality of the application. This options will disable the creation of the notification icon.
+
+#### Appearance
+
+Choose how Rancher Desktop renders its window: **System** (the default) follows the operating system's light or dark setting, **Light** always uses light mode, and **Dark** always uses dark mode. Earlier versions always followed the operating system.
 
 #### Known Issues and Limitations
 
@@ -57,6 +61,10 @@ Rancher Desktop normally remains running in the background even when the main ap
 
 Rancher Desktop shows the application status with a notification icon in the menu bar. The context menu of the icon provides more status information and provides quick access to other functionality of the application. This options will disable the creation of the notification icon.
 
+#### Appearance
+
+Choose how Rancher Desktop renders its window: **System** (the default) follows the operating system's light or dark setting, **Light** always uses light mode, and **Dark** always uses dark mode. Earlier versions always followed the operating system.
+
 #### Known Issues and Limitations
 
 * For Ubuntu operating systems and specifically versions >= 20.04.5 LTS, there is a known issue with hiding the tray icon in the preferences settings. Please see this [issue comment](https://github.com/rancher-sandbox/rancher-desktop/issues/4205#issuecomment-1533750167) for further information.
@@ -81,6 +89,10 @@ Rancher Desktop normally remains running in the background even when the main ap
 #### Notification Icon
 
 Rancher Desktop shows the application status with a notification icon. The context menu of the icon provides more status information and provides quick access to other functionality of the application. This options will disable the creation of the notification icon.
+
+#### Appearance
+
+Choose how Rancher Desktop renders its window: **System** (the default) follows the operating system's light or dark setting, **Light** always uses light mode, and **Dark** always uses dark mode. Earlier versions always followed the operating system.
 
 #### Known Issues and Limitations
 


### PR DESCRIPTION
Documents the dark-mode / theme preference added in 1.23 (Preferences > Application > Behavior). Verified against the rancher-desktop source.

## Changes (`docs/ui/preferences/application/behavior.md`)
- New **Appearance** section: **System** (the default, follows the OS), **Light**, and **Dark**. Earlier versions always followed the operating system theme.
- The page intro now mentions appearance.

The section is added to each OS tab to match the page's existing per-OS structure, and the staged Behavior screenshots already show the theme selector. Source: `components/Preferences/ApplicationBehavior.vue`, `settings.ts` (`Theme.SYSTEM` default), and the `application.behavior.theme` strings in `en-us.yaml`.

`yarn build` passes.

Closes #486
