### PR TITLE
Document the WSL Proxy bypass list

### DIFF
--- a/docs/ui/preferences/wsl/proxy.md
+++ b/docs/ui/preferences/wsl/proxy.md
@@ -17,7 +17,7 @@ This is an **experimental** setting.
 
 :::
 
-Rancher Desktop now allows local, corporate, or VPN proxy server support for Windows users. The implementation can be enabled or disabled through the `Proxy` tab to capture network traffic and forward it to an http proxy. Once all information has been input, click the `Apply` button to have changes immediately take effect.
+Rancher Desktop allows local, corporate, or VPN proxy server support for Windows users. The implementation can be enabled or disabled through the `Proxy` tab to capture network traffic and forward it to an http proxy. Once all information has been input, click the `Apply` button to have changes immediately take effect.
 
 ### Proxy address
 
@@ -27,6 +27,6 @@ Users can input their proxy IP address and port number in the `Proxy address` fi
 
 If your proxy requires authentication then users can input their username and password in the `Authentication information` fields.
 
-### No proxy hostname list
+### Proxy bypass list
 
-Default hostnames that should not be proxied will be displayed in this text area.
+This list holds the addresses that should bypass the proxy. Rancher Desktop pre-populates it with defaults, and you can add or remove entries. Each entry can be an IP address, a CIDR subnet, a domain name, or a wildcard pattern such as `*.example.com`.


### PR DESCRIPTION
Updates the WSL Proxy preferences doc for the 1.23 "Proxy bypass list" (#9803), verified against source.

## Changes (`docs/ui/preferences/wsl/proxy.md`)
- Rename **No proxy hostname list** → **Proxy bypass list** to match the UI label (`en-us.yaml` `virtualMachine.proxy.noproxy.legend`).
- Describe the editable add/remove list and the accepted entry formats — IP, CIDR, domain, and wildcard (e.g. `*.example.com`) — matching the field placeholder and `WslProxy.vue`.
- Drop "now" from the intro.

`yarn build` passes.

Closes #487
