### PR TITLE
Document the Installed extensions table columns

### DIFF
--- a/docs/ui/extensions.md
+++ b/docs/ui/extensions.md
@@ -57,9 +57,16 @@ The **Installed** tab is a view for all installed extensions on your Rancher Des
 </TabItem>
 </Tabs>
 
-#### Name
+#### Columns
 
-A list of names of installed extensions. Users can directly uninstall extensions by clicking the **Remove** button for the respective extension on the right hand side.
+Each installed extension is listed with details drawn from the extension's image labels:
+
+- **Name** — the extension's title.
+- **Vendor** — the extension's publisher.
+- **Description** — a short summary of what the extension does.
+- **More information** — a link to the extension's homepage or documentation.
+
+Click the **Remove** button on the right to uninstall an extension. When a newer version is available, an **Upgrade** button appears next to it.
 
 ### Remote Debugging Extensions
 


### PR DESCRIPTION
Documents the Installed-tab columns added in 1.23 (#8698), verified against `pkg/rancher-desktop/pages/extensions/installed.vue`.

## Changes (`docs/ui/extensions.md`)
- Replace the single **Name** subsection with a **Columns** section covering **Name**, **Vendor**, **Description**, and **More information** — all drawn from the extension's `org.opencontainers.image.*` labels.
- Document the row actions: **Remove**, and **Upgrade** when a newer version is available.

`yarn build` passes.

Closes #489
