### PR TITLE
Fix three inaccurate FAQ answers

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Rancher Desktop provides container management and a Kubernetes instance on the d
 
 #### **Q: Is there a Kubernetes Cluster Explorer available in Rancher Desktop?**
 
-**A:** Yes, the Rancher Dashboard is included. Open it by clicking the **Open cluster dashboard** option in the system tray menu.
+**A:** Yes, the Rancher Dashboard is included for the Kubernetes cluster that Rancher Desktop manages. Click the **Cluster Dashboard** button in the navigation sidebar, or choose **Open cluster dashboard** from the system tray menu.
 
 Learn more about [Rancher Desktop](./getting-started/introduction.md).
 Learn more about [Rancher](https://rancher.com/why-rancher).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -133,7 +133,7 @@ If you want to change the behavior of the mounts, that will also require [additi
 New-NetFirewallRule -DisplayName "WSL" -Direction Inbound -InterfaceAlias "vEthernet (WSL)" -Action Allow
 ```
 
-#### **Q: Can I map `host.docker.internal` or `host.rancher-desktop.internal` to `host-gateway` with the flag `--add-host`?
+#### **Q: Can I map `host.docker.internal` or `host.rancher-desktop.internal` to `host-gateway` with the flag `--add-host`?**
 
 **A:** No, the special value host-gateway is specific to Docker Desktop and is not yet supported in Rancher Desktop. However, you can access services running on the host machine from within a container using host.docker.internal or host.rancher-desktop.internal without passing the --add-host flag.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Rancher Desktop provides container management and a Kubernetes instance on the d
 
 #### **Q: Is there a Kubernetes Cluster Explorer available in Rancher Desktop?**
 
-**A:** Yes, the Rancher Dashboard is included as a feature preview in the release 1.2.1. Invoke the dashboard by clicking on **Dashboard** option in the system tray menu.
+**A:** Yes, the Rancher Dashboard is included. Open it by clicking the **Open cluster dashboard** option in the system tray menu.
 
 Learn more about [Rancher Desktop](./getting-started/introduction.md).
 Learn more about [Rancher](https://rancher.com/why-rancher).
@@ -53,7 +53,7 @@ https://docs.docker.com/desktop/
 
 #### **Q: What support, if any, is available for DNS over VPN on Windows?**
 
-**A:** An alternative DNS resolver for Windows has been implemented to address some of the VPN issues on Windows. It should support DNS lookup over VPN connections. It has to be enabled manually by editing an internal [configuration file](https://github.com/rancher-sandbox/rancher-desktop/issues/1899#issuecomment-1109128277).
+**A:** DNS lookups over VPN connections work out of the box on Windows. Rancher Desktop uses a host resolver by default, so no manual configuration is required.
 
 #### **Q: What does the "WSL Integration" tab do?**
 
@@ -140,9 +140,9 @@ New-NetFirewallRule -DisplayName "WSL" -Direction Inbound -InterfaceAlias "vEthe
 <!-- #985 -->
 #### **Q: I don't need the Kubernetes cluster deployed by Rancher Desktop; how do I disable it to save resources?**
 
-**A:** Open **Rancher Desktop** settings, click the cog to open **Preferences**, select **Kuberentes**, uncheck `Enable Kubernetes` feature is selected under **Kubernetes Settings**; uncheck this box to disable it.
+**A:** Open **Preferences**, select **Kubernetes**, and uncheck **Enable Kubernetes**.
 
-This will allow you to run just `containerd` or `dockerd` by without allocating resources for Kubernetes.
+This lets you run just `containerd` or `dockerd` without allocating resources for Kubernetes.
 
 <!-- #726 -->
 #### **Q: What's happening to the Kubernetes Image Manager (kim)?**


### PR DESCRIPTION
Corrects three inaccurate answers in `docs/faq.md`, verified against source.

## Changes
- **Cluster Explorer** — removed "feature preview in the release 1.2.1" and corrected the tray label to **Open cluster dashboard** (`pkg/rancher-desktop/main/tray.ts:83`).
- **DNS over VPN** — the alternative host resolver is now the default and the `hostResolver` setting was removed (`settingsImpl.ts` migration `_.unset(… 'virtualMachine.hostResolver')`), so the answer no longer tells users to edit an internal config file.
- **Disable Kubernetes** — rewrote the garbled answer (misspelled "Kuberentes", run-on sentence, stray "by").

`yarn build` passes.

Closes #491
