### PR TITLE
Remove the stale experimental warning from the Snapshots page

### DIFF
--- a/docs/ui/snapshots.md
+++ b/docs/ui/snapshots.md
@@ -27,12 +27,6 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 </Tabs>
 
-:::caution warning
-
-This is an **experimental** feature.
-
-:::
-
 A snapshot can be used to store the current configuration of your virtual machine and all associated settings. Snapshots are stored in a `snapshots` directory which are created at the below paths respective to your operating system:
 
 - macOS: `~/Library/Application\ Support/rancher-desktop/snapshots`


### PR DESCRIPTION
Removes the outdated "experimental" caution from `docs/ui/snapshots.md`. Snapshots is GA — `pkg/rancher-desktop/window/constants.ts` flags only `/Containers` and `/Volumes` as `experimental: true`, not `/Snapshots`.

Verified that `docs/ui/containers.md` and `docs/ui/volumes.md` correctly keep their experimental warnings (both are still flagged in source), so nothing changes there.

`yarn build` passes.

Closes #492
