### PR TITLE
Fix assorted typos and broken links

### DIFF
--- a/docs/how-to-guides/mirror-private-registry.md
+++ b/docs/how-to-guides/mirror-private-registry.md
@@ -13,7 +13,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -45,7 +45,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -78,7 +78,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 
@@ -97,7 +97,7 @@ mkdir -p /etc/rancher/k3s
 cat <<EOF >/etc/rancher/k3s/registries.yaml
 mirrors:
   "localhost:5000":
-  endpoint:
+    endpoint:
     - http://localhost:5000
 EOF
 ```

--- a/docs/how-to-guides/running-air-gapped.md
+++ b/docs/how-to-guides/running-air-gapped.md
@@ -45,7 +45,7 @@ Suppose there are three versions of `k3s` in the `rancher-desktop` cache.
 - 1.21.14
 
 But suppose that on this system we only ran `kubectl` when using versions `1.24.3` and `1.21.14`. This means that
-the `~/.kuberlr/PLATFORM-ARCH/` directory (`$env:HOMEDRIVE%\$env:HOMEPATH/.kuberlr/windows-amd64` on Windows) will contain only two files:
+the `~/.kuberlr/PLATFORM-ARCH/` directory (`$env:HOMEDRIVE$env:HOMEPATH/.kuberlr/windows-amd64` on Windows) will contain only two files:
 
 - kubectl1.24.3
 
@@ -87,17 +87,17 @@ wget https://github.com/k3s-io/k3s/releases/download/v1.24.3%2Bk3s1/k3s
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
   <TabItem value="Windows">
 
-On Windows, the cache directory is at `$env:HOMEDRIVE%\$env:HOMEPATH\AppData\Local\rancher-desktop\cache\k3s`, and can be created with the command
+On Windows, the cache directory is at `$env:HOMEDRIVE$env:HOMEPATH\AppData\Local\rancher-desktop\cache\k3s`, and can be created with the command
 
 ```
-mkdir -Force $env:HOMEDRIVE%\$env:HOMEPATH\AppData\Local\rancher-desktop\cache\k3s
+mkdir -Force $env:HOMEDRIVE$env:HOMEPATH\AppData\Local\rancher-desktop\cache\k3s
 ```
 
 Assuming you have some source media, you would also run the following commands to pre-populate the cache:
 
 ```
-copy-item -Force $env:SOURCEDISK\k3s-versions.json $env:HOMEDRIVE%\$env:HOMEPATH\AppData\Local\rancher-desktop\cache\
-copy-item -Recurse -Force $env:SOURCEDISK\v<MAJOR>.<MINOR>.<PATCH>+k3s<BUILD> $env:HOMEDRIVE%\$env:HOMEPATH\AppData\Local\rancher-desktop\cache\k3s\
+copy-item -Force $env:SOURCEDISK\k3s-versions.json $env:HOMEDRIVE$env:HOMEPATH\AppData\Local\rancher-desktop\cache\
+copy-item -Recurse -Force $env:SOURCEDISK\v<MAJOR>.<MINOR>.<PATCH>+k3s<BUILD> $env:HOMEDRIVE$env:HOMEPATH\AppData\Local\rancher-desktop\cache\k3s\
 ```
 
   </TabItem>
@@ -131,7 +131,7 @@ cp -r $SOURCEDISK/v<MAJOR>.<MINOR>.<PATCH>+k3s<BUILD> $CACHEDIR/k3s/
 
 The location of this directory is more straightforward. On all platforms, it's at `HOME/.kuberlr/PLATFORM-ARCH` where:
 
-- `HOME` is the home directory: usually `$env:HOMEDRIVE%\$env:HOMEPATH` on Windows, and `~` or `$HOME` on macOS and Linux.
+- `HOME` is the home directory: usually `$env:HOMEDRIVE$env:HOMEPATH` on Windows, and `~` or `$HOME` on macOS and Linux.
 - `PLATFORM` is one of `windows`, `linux`, or `darwin`.
 - `ARCH` is `aarch64` on M1 machines, and `amd64` everywhere else.
 

--- a/docs/how-to-guides/transfer-container-images.md
+++ b/docs/how-to-guides/transfer-container-images.md
@@ -27,26 +27,26 @@ nerdctl save -o local-images.tar image1:tag1 image2:tag2
 
 - Save all images in a namespace
 
-Below two commands use [jq](https://stedolan.github.io/jq/) for JSON parsing. The long command performs the below steps:
+Below two commands use [jq](https://jqlang.github.io/jq/) for JSON parsing. The long command performs the below steps:
 
 - The `nerdctl -n k8s.io image ls` sub command gets the list of all images present in the `k8s.io` namespace, hence doesn't include images from any other namespace, `default` for instance.
 - The `jq` sub command filters and formats the images list from the previous step.
   - The `select(.Repository!=\"<none>\")` part of the command skips those images with repository having a value of `<none>`.
   - The `if (.Tag=="<none>") then .Repository else (.Repository+":"+.Tag) end')` part of the command formats the name of the images to be just the `<Repository>` or `<Repository>:<Tag>` depending on whether a image tag has a value of `<none>` or not.
-- Finally the `nerdctl -n k8s.io save -o all-local-images-in-namespace.tar` part of the command saves the filtered and formatted images list from the previous two steps into a tar file. 
+- Finally the `nerdctl -n k8s.io save -o all-local-images.tar` part of the command saves the filtered and formatted images list from the previous two steps into a tar file. 
 
 <Tabs groupId="shell">
   <TabItem value="Bash" default>
 
 ```
-nerdctl -n k8s.io save -o all-local-images-in-namespace.tar $(nerdctl -n k8s.io image ls --format '{{json .}}' | jq -r 'select(.Repository!="<none>") | if (.Tag=="<none>") then .Repository else (.Repository+":"+.Tag) end')
+nerdctl -n k8s.io save -o all-local-images.tar $(nerdctl -n k8s.io image ls --format '{{json .}}' | jq -r 'select(.Repository!="<none>") | if (.Tag=="<none>") then .Repository else (.Repository+":"+.Tag) end')
 ```
 
   </TabItem>
   <TabItem value="PowerShell">
 
 ```
-nerdctl -n k8s.io save -o all-local-images-in-namespace.tar $(nerdctl -n k8s.io image ls --format '{{json .}}' | jq -r 'select(.Repository!=\"<none>\") | if (.Tag==\"<none>\") then .Repository else (.Repository+\":\"+.Tag) end')
+nerdctl -n k8s.io save -o all-local-images.tar $(nerdctl -n k8s.io image ls --format '{{json .}}' | jq -r 'select(.Repository!=\"<none>\") | if (.Tag==\"<none>\") then .Repository else (.Repository+\":\"+.Tag) end')
 ```
 
   </TabItem>
@@ -67,26 +67,26 @@ docker save -o local-images.tar image1:tag1 image2:tag2
 
 - Save all local images
 
-Below two commands use [jq](https://stedolan.github.io/jq/) for JSON parsing. The long command performs the below steps:
+Below two commands use [jq](https://jqlang.github.io/jq/) for JSON parsing. The long command performs the below steps:
 
 - The `docker image ls` sub command gets the list of all local images.
 - The `jq` sub command filters and formats the images list from the previous step.
   - The `select(.Repository!=\"<none>\")` part of the command skips those images with repository having a value of `<none>`.
   - The `if (.Tag=="<none>") then .Repository else (.Repository+":"+.Tag) end')` part of the command formats the name of the images to be just the `<Repository>` or `<Repository>:<Tag>` depending on whether a image tag has a value of `<none>` or not.
-- Finally the `docker save -o all-local-images-in-namespace.tar` part of the command saves the filtered and formatted images list from the previous two steps into a tar file. 
+- Finally the `docker save -o all-local-images.tar` part of the command saves the filtered and formatted images list from the previous two steps into a tar file. 
 
 <Tabs groupId="shell">
   <TabItem value="Bash" default>
 
 ```
-docker save -o all-local-images-in-namespace.tar $(docker image ls --format '{{json .}}' | jq -r 'select(.Repository!="<none>") | if (.Tag=="<none>") then .Repository else (.Repository+":"+.Tag) end')
+docker save -o all-local-images.tar $(docker image ls --format '{{json .}}' | jq -r 'select(.Repository!="<none>") | if (.Tag=="<none>") then .Repository else (.Repository+":"+.Tag) end')
 ```
 
   </TabItem>
   <TabItem value="PowerShell">
 
 ```
-docker save -o all-local-images-in-namespace.tar $(docker image ls --format '{{json .}}' | jq -r 'select(.Repository!=\"<none>\") | if (.Tag==\"<none>\") then .Repository else (.Repository+\":\"+.Tag) end')
+docker save -o all-local-images.tar $(docker image ls --format '{{json .}}' | jq -r 'select(.Repository!=\"<none>\") | if (.Tag==\"<none>\") then .Repository else (.Repository+\":\"+.Tag) end')
 ```
 
   </TabItem>

--- a/docs/ui/preferences/virtual-machine/emulation.md
+++ b/docs/ui/preferences/virtual-machine/emulation.md
@@ -13,7 +13,7 @@ title: Emulation (macOS)
 
 The **VZ** option is enabled by default and uses the native macOS [Virtualization.Framework](https://developer.apple.com/documentation/virtualization) for running a guest machine. You can switch the virtual machine type after the first run.
 
-The suboption **VZ option** can also be enabled if using **VZ** as your virtual machine type. The suboption enables [Rosetta support](https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta) and allows users to run applications that contain x86_64 instructions on Apple hardware.
+The **Enable Rosetta support** suboption can also be enabled when using **VZ** as your virtual machine type. It turns on [Rosetta](https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta) so you can run applications that contain x86_64 instructions on Apple silicon. This suboption appears only on Apple silicon.
 
 ### QEMU
 

--- a/docs/ui/preferences/virtual-machine/volumes.md
+++ b/docs/ui/preferences/virtual-machine/volumes.md
@@ -26,7 +26,7 @@ import TabsConstants from '@site/core/TabsConstants';
 </TabItem>
 </Tabs>
 
-Users can enable the "[reverse-sshfs](https://lima-vm.io/docs/config/mount/#reverse-sshfs)" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then intitiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
+Users can enable the "[reverse-sshfs](https://lima-vm.io/docs/config/mount/#reverse-sshfs)" mount type from the `Volumes` tab. This exposes the filesystem by running an SFTP server on the host. The host instance will then initiate an SSH connection into the guest allowing it to connect to the SFTP server. This is the default mount type used in the application.
 
 ### 9p
 
@@ -58,7 +58,7 @@ Specifies a caching policy that has a default setting as `mmap`. The caching opt
 Users can specify the number of bytes to use for the "9p" packet size. The minimum value is 4 KiB and the default size is 128 KiB.
 
 * Protocol Version:
-Users can select the "9p" protocol version. The options include `[9p2000, 9p2000.u, 9p2000.L]` and the default protocol setting is `9p200.L`.
+Users can select the "9p" protocol version. The options include `[9p2000, 9p2000.u, 9p2000.L]` and the default protocol setting is `9p2000.L`.
 
 * Security Model:
 Users can select a supported security model with options being `[passthrough, mapped-xattr, mapped-file, none]`. The default security setting value is `none`.

--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -14,7 +14,7 @@ The Integrations tab allows for the option to make the Rancher Desktop Kubernete
 With WSL, memory and CPU allocation is configured globally across all Linux distributions. Refer to the [WSL documentation] for instructions.
 
 [WSL documentation]:
-https://docs.microsoft.com/en-us/windows/wsl/wsl-config#options-for-wslconfig
+https://learn.microsoft.com/en-us/windows/wsl/wsl-config#options-for-wslconfig
 
 ### `~/.kube/config`
 

--- a/docs/ui/troubleshooting.md
+++ b/docs/ui/troubleshooting.md
@@ -47,7 +47,7 @@ To reset Kubernetes:
 
 ### Factory Reset
 
-Remove the cluster and all other Rancher Desktop settings. To continue The initial setup procedure must be done again.
+Remove the cluster and all other Rancher Desktop settings. To continue, the initial setup procedure must be done again.
 
 To perform a factory reset:
 


### PR DESCRIPTION
A sweep of verified typos and broken links across the Next docs.

| File | Fix |
|---|---|
| `running-air-gapped.md` | Remove the leftover cmd `%` from the PowerShell `$env:HOMEDRIVE$env:HOMEPATH` paths (6×) |
| `mirror-private-registry.md` | Fix the Windows `registries.yaml` indentation (`endpoint` now nested under the host) so k3s can parse it; correct the wrong-case `provisioning-scripts.md#macos--linux` / `#windows` anchors (clears the build's broken-anchor warning for the Next docs) |
| `virtual-machine/volumes.md` | `9p200.L` → `9p2000.L`; "intitiate" → "initiate" |
| `virtual-machine/emulation.md` | Name the suboption by its real label **Enable Rosetta support** and note it appears only on Apple silicon |
| `ui/troubleshooting.md` | Fix the run-on sentence in the Factory Reset note |
| `transfer-container-images.md` | `jqlang.github.io/jq` (jq moved); neutral `all-local-images.tar` filename |
| `wsl/integrations.md` | `learn.microsoft.com` (current domain) |

The `faq.md` unclosed-bold item from the original sweep moves to the FAQ PR (#511, same file); the `vs-code-docker.md` `task.json` item moves to the dev-workflow-guides issue (#494), where that guide is reworked and tested.

`yarn build` passes. (The remaining `mirror-private-registry` broken-anchor warnings are in the frozen `versioned_docs`, out of scope for the Next docs.)

Closes #493
