### PR TITLE
Clarify that provisioning scripts run regardless of Kubernetes

### DIFF
--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -79,7 +79,7 @@ Please note that the directory will be deleted during a factory-reset, so ensure
 
 - Open the `%LOCALAPPDATA%\rancher-desktop\provisioning` directory. An example of the full path: `C:\Users\Joe\AppData\Local\rancher-desktop\provisioning`.
 
-- Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts its Kubernetes backend_ (if enabled). Such files will run within the Rancher Desktop WSL context.
+- Note that any files with a file extension of `.start`, such as `k3s-overrides.start`, can be executed when _Rancher Desktop starts the WSL backend_, whether or not Kubernetes is enabled. Such files will run within the Rancher Desktop WSL context.
 
 Example flow for `.start` files:
 - Rancher Desktop internal setup
@@ -98,7 +98,7 @@ insecure_registry = true
 EOF
 ```
 
-- Note that files with a file extension of `.stop`, such as `wipe-data.stop`, can be executed _after Rancher Desktop shuts down its Kubernetes backend_ (if enabled). Such files will run within the same Rancher Desktop WSL context.
+- Note that files with a file extension of `.stop`, such as `wipe-data.stop`, can be executed _after Rancher Desktop shuts down the WSL backend_, whether or not Kubernetes is enabled. Such files will run within the same Rancher Desktop WSL context.
 
 Example flow for `.stop` files:
 - Stop `k3s`, `dockerd` or `containerd`

--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -69,8 +69,6 @@ env:
 
 ## Windows
 
-**Caution:** You can only utilize these provisioning scripts for Rancher Desktop, version 1.1.0 or later, on Windows.
-
 - Run Rancher Desktop at least once to allow it to create the configuration `provisioning` directory.
 
 :::note


### PR DESCRIPTION
Fixes docs#107. The Windows `.start`/`.stop` provisioning scripts run whenever Rancher Desktop starts or stops the WSL backend, regardless of whether Kubernetes is enabled — `runProvisioningScripts()` is called unconditionally in the start sequence (`pkg/rancher-desktop/backend/wsl.ts:1477`, outside the Kubernetes-install block).

## Changes (`docs/how-to-guides/provisioning-scripts.md`)
- Reword the `.start` and `.stop` notes: they run when Rancher Desktop starts/stops the **WSL backend**, **whether or not Kubernetes is enabled** (was "starts its Kubernetes backend (if enabled)").

`yarn build` passes.

Closes #107
