### PR TITLE
Document credential storage, shared host paths, and localhostOnly

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -165,10 +165,13 @@ sudo usermod -a -G kvm "$USER"
 Then reboot in order to make these changes take effect.
 
 
-#### `pass` Setup
+#### Credential Storage
 
-By default, Rancher Desktop uses `pass` to securely store credentials
-passed via `docker login` and `nerdctl login`. `pass` requires a small amount
+Rancher Desktop automatically configures Docker and `nerdctl` to store the
+credentials from `docker login` and `nerdctl login` in your platform's native
+secret store: the macOS keychain (`osxkeychain`) on macOS and the Windows
+Credential Manager (`wincred`) on Windows, both of which work without any setup.
+On Linux it uses `pass`, which requires a small amount
 of setup if this is the first time it has been used on your machine. If you don't
 intend to use `docker login` or `nerdctl login` you don't have to set up
 `pass` - just remember that if you use them in the future, you must set it

--- a/docs/ui/preferences/kubernetes.md
+++ b/docs/ui/preferences/kubernetes.md
@@ -82,3 +82,11 @@ This option requires that the [WebAssembly](./container-engine/general.md) suppo
 Rancher Desktop automatically installs the [spin cli](https://spinframework.dev/v2/index) and the [kube plugin](https://github.com/spinkube/spin-plugin-kube) to help develop and deploy Spin applications on Kubernetes.
 
 :::
+
+#### Binding Kubernetes services (Windows)
+
+On Windows, when Rancher Desktop is installed with administrative access, Kubernetes ingress and `LoadBalancer` services bind to all network interfaces (`0.0.0.0`), so they are reachable from other machines on the network. There is no GUI control for this. To restrict these services to `127.0.0.1` only, use `rdctl`:
+
+```console
+rdctl set --kubernetes.ingress.localhost-only=true
+```

--- a/docs/ui/preferences/virtual-machine/volumes.md
+++ b/docs/ui/preferences/virtual-machine/volumes.md
@@ -79,3 +79,12 @@ Users can select a supported security model with options being `[passthrough, ma
 </Tabs>
 
 Users can enable the [`virtiofs`](https://virtio-fs.gitlab.io/) mount type from the `Volumes` tab. This is implemented using the Apple `Virtualization.Framework` shared directory device.
+
+## Shared Host Directories
+
+Only files under directories that Rancher Desktop mounts into the virtual machine can be bind-mounted into containers (for example with `docker run -v` or `nerdctl run -v`). The following host directories are shared by default:
+
+- **macOS:** your home directory, `/Volumes`, `/var/folders`, `/private/tmp`, and `/tmp/rancher-desktop`. Paths under `$TMPDIR` resolve below `/var/folders`, so they work as well.
+- **Linux:** your home directory and `/tmp/rancher-desktop`.
+
+To share a directory outside these locations, add it as an extra mount with a [provisioning script](../../../how-to-guides/provisioning-scripts.md).


### PR DESCRIPTION
Documents three features that have been in the product for several releases but were never documented. Verified against the rancher-desktop source.

## Changes
- **`getting-started/installation.md`** — generalize the credential-storage section: Rancher Desktop configures the native secret store per OS — macOS keychain (`osxkeychain`), Windows Credential Manager (`wincred`), and `pass` on Linux. Source: `utils/dockerDirManager.ts` `getCredsStoreFor()`. (Only the Linux `pass` setup was documented before.)
- **`ui/preferences/virtual-machine/volumes.md`** — new **Shared Host Directories** section listing the host paths mounted into the VM (and thus bind-mountable into containers): macOS home, `/Volumes`, `/var/folders`, `/private/tmp`, `/tmp/rancher-desktop`; Linux home and `/tmp/rancher-desktop`. Source: `backend/lima.ts` `getMounts()`.
- **`ui/preferences/kubernetes.md`** — document `kubernetes.ingress.localhostOnly` (no GUI): on Windows admin installs, K8s services bind to `0.0.0.0` by default; restrict with `rdctl set --kubernetes.ingress.localhost-only=true`. Source: `settings.ts`, `backend/wsl.ts`.

## Notes
- The credential-storage note currently sits in the (Linux) installation section; relocating it per-OS is left to the IA restructure (#503).
- `localhostOnly` also appears in the non-GUI settings inventory on #479, which will link here.
- The related `0.0.0.0` published-port default and `--net=host` support are left to the networking how-to (#496) to avoid overlap.

`yarn build` passes.

Closes #501
