### PR TITLE
Document leftover-data cleanup for uninstall on all platforms

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -67,6 +67,27 @@ Note: The recommended installation method is via the DMG from GitHub. The Homebr
 1. Select it and choose **File > Move to Trash**.
 1. To delete the app, Finder > Empty Trash.
 
+Moving the app to the Trash removes the application but leaves Rancher Desktop's data behind. For a more thorough cleanup, run a [Factory Reset](../ui/troubleshooting.md#factory-reset) (or `rdctl reset --factory`) before deleting the app. A factory reset removes most data and the virtual machine. By default it keeps your snapshots and the downloaded Kubernetes image cache; run `rdctl reset --factory --cache` (or tick the corresponding checkbox in the UI) to remove the image cache as well. **Snapshots are always kept.**
+
+To remove everything, including the data that a factory reset keeps, also delete these directories:
+
+```console
+rm -rf ~/Library/Application\ Support/rancher-desktop \
+       ~/Library/Application\ Support/Rancher\ Desktop \
+       ~/Library/Preferences/rancher-desktop \
+       ~/Library/Caches/rancher-desktop \
+       ~/Library/Logs/rancher-desktop \
+       ~/.rd
+```
+
+Snapshots are stored under `~/Library/Application Support/rancher-desktop/snapshots`, so deleting that directory removes them as well.
+
+If you created a [deployment profile](deployment.md), it survives both a factory reset and an uninstall. Delete the user profile at `~/Library/Preferences/io.rancherdesktop.profile.{defaults,locked}.plist`, and a system profile at `/Library/Managed Preferences/io.rancherdesktop.profile.{defaults,locked}.plist` (which requires administrator privileges).
+
+:::note
+Before installing an older version of Rancher Desktop, perform this clean uninstall first. An older version may not be able to read data written by a newer one.
+:::
+
 ## Windows
 
 ### Requirements
@@ -122,6 +143,17 @@ https://github.com/rancher-sandbox/rancher-desktop/releases
 1. Click **Uninstall** and click it again when the confirmation appears.
 1. Follow the prompts on the Rancher Desktop uninstaller to proceed.
 1. Click **Finish** when complete.
+
+The uninstaller removes the application but leaves Rancher Desktop's data and its WSL distributions behind. For a more thorough cleanup, run a [Factory Reset](../ui/troubleshooting.md#factory-reset) (or `rdctl reset --factory`) first, then unregister the WSL distributions and delete the remaining data:
+
+```console
+wsl --unregister rancher-desktop
+wsl --unregister rancher-desktop-data
+```
+
+Then delete the `%LOCALAPPDATA%\rancher-desktop` directory. By default a factory reset keeps your snapshots and the downloaded Kubernetes image cache; deleting this directory removes those as well.
+
+If you created a [deployment profile](deployment.md), it survives the uninstall. Delete it from the registry under `HKEY_CURRENT_USER\Software\Policies\Rancher Desktop`, and a system profile under `HKEY_LOCAL_MACHINE\Software\Policies\Rancher Desktop` (which requires an elevated shell).
 
 ## Linux
 
@@ -295,6 +327,21 @@ https://github.com/TheAssassin/AppImageLauncher
 ### Uninstalling AppImage
 
 Simply delete the AppImage. That's it!
+
+### Removing leftover data on Linux
+
+Removing the package or the AppImage leaves Rancher Desktop's data behind. For a more thorough cleanup, run a [Factory Reset](../ui/troubleshooting.md#factory-reset) (or `rdctl reset --factory`) first, then delete:
+
+```console
+rm -rf ~/.local/share/rancher-desktop \
+       ~/.config/rancher-desktop \
+       ~/.cache/rancher-desktop \
+       ~/.rd
+```
+
+By default a factory reset keeps your snapshots (under `~/.local/share/rancher-desktop/snapshots`) and the downloaded Kubernetes image cache; deleting these directories removes those as well.
+
+If you created a [deployment profile](deployment.md), it survives the uninstall. Delete the user profile at `~/.config/rancher-desktop.{defaults,locked}.json`, and a system profile under `/etc/rancher-desktop/` (which requires root).
 
 ## Proxy Environments: Important URL Patterns
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -153,7 +153,7 @@ wsl --unregister rancher-desktop-data
 
 Then delete the `%LOCALAPPDATA%\rancher-desktop` directory. By default a factory reset keeps your snapshots and the downloaded Kubernetes image cache; deleting this directory removes those as well.
 
-If you created a [deployment profile](deployment.md), it survives the uninstall. Delete it from the registry under `HKEY_CURRENT_USER\Software\Policies\Rancher Desktop`, and a system profile under `HKEY_LOCAL_MACHINE\Software\Policies\Rancher Desktop` (which requires an elevated shell).
+If you created a [deployment profile](deployment.md), it survives the uninstall. Delete it from the registry under `HKEY_CURRENT_USER\Software\Policies\Rancher Desktop`, and a system profile under `HKEY_LOCAL_MACHINE\Software\Policies\Rancher Desktop` (which requires Administrator privileges).
 
 ## Linux
 


### PR DESCRIPTION
Addresses docs#467, rd#1725, and rd#7316. Uninstalling Rancher Desktop leaves its data behind on every platform, and a factory reset deliberately keeps snapshots and the Kubernetes image cache (`delete_data_unix.go` excludes `Snapshots`/`ContainerdShims`; the cache is removed only when "delete container images" is chosen). The uninstall docs only covered removing the app.

## Changes (`docs/getting-started/installation.md`)
- **macOS** — after the Trash steps, document a Factory-Reset-first cleanup and the exact leftover directories to delete: `~/Library/Application Support/{rancher-desktop, Rancher Desktop}`, `~/Library/Preferences/rancher-desktop`, `~/Library/Caches/rancher-desktop`, `~/Library/Logs/rancher-desktop`, `~/.rd`, and the deployment-profile plists. Note that snapshots live under Application Support, and add a downgrade note (clean uninstall before installing an older version).
- **Windows** — unregister the `rancher-desktop` and `rancher-desktop-data` WSL distributions and delete `%LOCALAPPDATA%\rancher-desktop`.
- **Linux** — new "Removing leftover data" section: `~/.local/share/rancher-desktop`, `~/.config/rancher-desktop`, `~/.cache/rancher-desktop`, `~/.rd`.
- Each section notes that a factory reset keeps snapshots and the image cache, so the directories must be deleted to remove those too.

All paths verified against `src/go/rdctl/pkg/paths/paths_*.go` and the resolved values in the `*_test.go` files. One correction from the original issue: the integration binaries live in `~/.rd/bin`, not `/usr/local/bin` symlinks.

`yarn build` passes.

Closes #500
