### PR TITLE
Generate canonical links automatically

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,11 +17,10 @@ jobs:
       - name: Internal links must be relative
         run: |
           # Internal links must use relative paths (../foo/bar.md) so the build
-          # validates them. lychee no longer checks absolute
-          # https://docs.rancherdesktop.io/<path> links, so forbid them in content
-          # to keep internal-link typos covered. The per-page canonical <link>
-          # tag is the only allowed exception.
-          bad=$(grep -rnE 'https://docs\.rancherdesktop\.io/[^ )"]' docs --include='*.md' | grep -v 'rel="canonical"' || true)
+          # validates them. An absolute https://docs.rancherdesktop.io/<path> link
+          # to a page added in the same PR would 404 in the link check until that
+          # page is deployed, so forbid absolute self-links in content.
+          bad=$(grep -rnE 'https://docs\.rancherdesktop\.io/[^ )"]' docs --include='*.md' || true)
           if [ -n "$bad" ]; then
             echo "$bad"
             echo "::error::Internal links must be relative (e.g. ../getting-started/installation.md), not absolute https://docs.rancherdesktop.io/... URLs."

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/docs/how-to-guides/create-multi-node-cluster.md
+++ b/docs/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/docs/how-to-guides/generating-deployment-profiles.md
+++ b/docs/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/docs/how-to-guides/hello-world-example.md
+++ b/docs/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/docs/how-to-guides/increasing-open-file-limit.md
+++ b/docs/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/docs/how-to-guides/installing-uninstalling-extensions.md
+++ b/docs/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/docs/how-to-guides/migrating-images.md
+++ b/docs/how-to-guides/migrating-images.md
@@ -2,10 +2,6 @@
 title: Migrating Moby Images Between Storage Drivers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/migrating-images"/>
-</head>
-
 Rancher Desktop stores images using two storage drivers when running the moby (docker) container engine: the **classic storage driver** and the **containerd snapshotter**. This page explains why images become hidden and how to access them.
 
 ## Background

--- a/docs/how-to-guides/mirror-private-registry.md
+++ b/docs/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/how-to-guides/provisioning-scripts.md
+++ b/docs/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/docs/how-to-guides/rancher-on-rancher-desktop.md
+++ b/docs/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/docs/how-to-guides/running-air-gapped.md
+++ b/docs/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/docs/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/docs/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/docs/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/docs/how-to-guides/traefik-ingress-example.md
+++ b/docs/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/docs/how-to-guides/transfer-container-images.md
+++ b/docs/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/docs/how-to-guides/using-testcontainers.md
+++ b/docs/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers with Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docs/how-to-guides/vs-code-docker.md
+++ b/docs/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/docs/how-to-guides/vs-code-remote-containers.md
+++ b/docs/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/docs/references/architecture.md
+++ b/docs/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/docs/references/bundled-utilities.md
+++ b/docs/references/bundled-utilities.md
@@ -6,10 +6,6 @@ import Version120 from '../bundled-utilities-version-info/v1.20.0.md';
 import Version121 from '../bundled-utilities-version-info/v1.21.0.md';
 import Version122 from '../bundled-utilities-version-info/v1.22.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/docs/troubleshooting-tips.md
+++ b/docs/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/docs/tutorials/using-persistent-storage.md
+++ b/docs/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/docs/tutorials/working-with-containers.md
+++ b/docs/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/docs/tutorials/working-with-images.md
+++ b/docs/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/docs/tutorials/working-with-webassembly.md
+++ b/docs/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/docs/ui/containers.md
+++ b/docs/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/diagnostics.md
+++ b/docs/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/docs/ui/extensions.md
+++ b/docs/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/docs/ui/general.md
+++ b/docs/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/docs/ui/images.md
+++ b/docs/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/port-forwarding.md
+++ b/docs/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/preferences/application/behavior.md
+++ b/docs/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/docs/ui/preferences/application/environment.md
+++ b/docs/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/docs/ui/preferences/application/general.md
+++ b/docs/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/docs/ui/preferences/container-engine/allowed-images.md
+++ b/docs/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/docs/ui/preferences/container-engine/general.md
+++ b/docs/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/docs/ui/preferences/kubernetes.md
+++ b/docs/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/preferences/virtual-machine/emulation.md
+++ b/docs/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### VZ
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)

--- a/docs/ui/preferences/virtual-machine/hardware.md
+++ b/docs/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/docs/ui/preferences/virtual-machine/volumes.md
+++ b/docs/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/docs/ui/preferences/wsl/integrations.md
+++ b/docs/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/docs/ui/preferences/wsl/proxy.md
+++ b/docs/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/docs/ui/snapshots.md
+++ b/docs/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/troubleshooting.md
+++ b/docs/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docs/ui/volumes.md
+++ b/docs/ui/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,6 +12,10 @@ const config = {
   tagline: 'Rancher Desktop Docs',
   url: 'https://docs.rancherdesktop.io',
   baseUrl: '/',
+  // GitHub Pages serves every page at its trailing-slash URL and 301-redirects
+  // the slash-less form, so emit trailing slashes to keep canonical links,
+  // og:url, the sitemap, and internal links off the redirect.
+  trailingSlash: true,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',

--- a/lychee.toml
+++ b/lychee.toml
@@ -25,8 +25,4 @@ exclude = [
     "^https://storage.googleapis.com/kubernetes-release/release",
     # Repo has been deleted, needs to be fixed: https://github.com/rancher-sandbox/docs.rancherdesktop.io/issues/442
     "^https://github.com/bwateratmsft/samples",
-    # Self-referencing canonical links 404 until the page is deployed. The
-    # relative-link guard in the Test deployment workflow catches internal-link
-    # typos instead, so internal links are still verified.
-    "^https://docs.rancherdesktop.io",
 ]

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Metadata from '@theme-original/DocItem/Metadata';
+import {
+  useActivePlugin,
+  useDoc,
+  useDocVersionSuggestions,
+} from '@docusaurus/plugin-content-docs/client';
+
+function addTrailingSlash(path) {
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
+// Point the canonical URL at the latest version of this page, so search
+// engines fold every version — and the unreleased "Next" docs — into the
+// latest release instead of indexing duplicates.
+function CanonicalToLatest() {
+  const {siteConfig: {url}} = useDocusaurusContext();
+  const {metadata} = useDoc();
+  const {pluginId} = useActivePlugin({failfast: true});
+  const {latestDocSuggestion} = useDocVersionSuggestions(pluginId);
+  // latestDocSuggestion is undefined when this page no longer exists in the
+  // latest version; fall back to the page's own URL.
+  const canonicalUrl =
+    url + addTrailingSlash(latestDocSuggestion?.path ?? metadata.permalink);
+  return (
+    <Head>
+      <link rel="canonical" href={canonicalUrl} />
+      <meta property="og:url" content={canonicalUrl} />
+    </Head>
+  );
+}
+
+export default function MetadataWrapper(props) {
+  return (
+    <>
+      <Metadata {...props} />
+      <CanonicalToLatest />
+    </>
+  );
+}

--- a/versioned_docs/version-1.10/faq.md
+++ b/versioned_docs/version-1.10/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.10/getting-started/deployment.md
+++ b/versioned_docs/version-1.10/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.10/getting-started/installation.md
+++ b/versioned_docs/version-1.10/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.10/getting-started/introduction.md
+++ b/versioned_docs/version-1.10/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.10/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.10/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.10/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.10/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.10/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.10/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.10/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.10/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.10/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.10/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.10/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.10/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.10/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.10/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.10/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.10/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.10/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.10/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.10/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.10/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.10/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.10/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.10/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.10/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.10/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.10/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.10/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.10/references/architecture.md
+++ b/versioned_docs/version-1.10/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.10/references/bundled-utilities.md
+++ b/versioned_docs/version-1.10/references/bundled-utilities.md
@@ -9,10 +9,6 @@ import Version190 from '../bundled-utilities-version-info/v1.9.0.md';
 import Version191 from '../bundled-utilities-version-info/v1.9.1.md';
 import Version110 from '../bundled-utilities-version-info/v1.10.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.10/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.10/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.10/troubleshooting-tips.md
+++ b/versioned_docs/version-1.10/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.10/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.10/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.10/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.10/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.10/ui/diagnostics.md
+++ b/versioned_docs/version-1.10/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.10/ui/extensions.md
+++ b/versioned_docs/version-1.10/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.10/ui/general.md
+++ b/versioned_docs/version-1.10/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.10/ui/images.md
+++ b/versioned_docs/version-1.10/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Images** tab, allows you to manage the images on your virtual machine.

--- a/versioned_docs/version-1.10/ui/port-forwarding.md
+++ b/versioned_docs/version-1.10/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.10/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.10/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.10/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.10/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.10/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.10/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.10/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.10/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.10/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.10/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.10/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.10/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (macOS)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable socket-vmnet

--- a/versioned_docs/version-1.10/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.10/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.10/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.10/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.10/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.10/ui/preferences/wsl/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (Windows)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel

--- a/versioned_docs/version-1.10/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.10/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.10/ui/troubleshooting.md
+++ b/versioned_docs/version-1.10/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.11/faq.md
+++ b/versioned_docs/version-1.11/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.11/getting-started/deployment.md
+++ b/versioned_docs/version-1.11/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.11/getting-started/installation.md
+++ b/versioned_docs/version-1.11/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.11/getting-started/introduction.md
+++ b/versioned_docs/version-1.11/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.11/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.11/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.11/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.11/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](https://docs.rancherdesktop.io/getting-started/deployment).
 
 :::note

--- a/versioned_docs/version-1.11/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.11/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.11/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.11/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.11/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.11/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.11/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.11/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.11/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.11/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.11/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.11/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.11/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.11/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.11/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.11/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.11/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.11/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.11/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.11/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.11/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.11/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.11/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.11/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.11/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.11/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.11/references/architecture.md
+++ b/versioned_docs/version-1.11/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.11/references/bundled-utilities.md
+++ b/versioned_docs/version-1.11/references/bundled-utilities.md
@@ -10,10 +10,6 @@ import Version191 from '../bundled-utilities-version-info/v1.9.1.md';
 import Version110 from '../bundled-utilities-version-info/v1.10.0.md';
 import Version111 from '../bundled-utilities-version-info/v1.11.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.11/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.11/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.11/troubleshooting-tips.md
+++ b/versioned_docs/version-1.11/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.11/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.11/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.11/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.11/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.11/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.11/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.11/ui/containers.md
+++ b/versioned_docs/version-1.11/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.11/ui/diagnostics.md
+++ b/versioned_docs/version-1.11/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.11/ui/extensions.md
+++ b/versioned_docs/version-1.11/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.11/ui/general.md
+++ b/versioned_docs/version-1.11/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.11/ui/images.md
+++ b/versioned_docs/version-1.11/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.11/ui/port-forwarding.md
+++ b/versioned_docs/version-1.11/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.11/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.11/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.11/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.11/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.11/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.11/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.11/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.11/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.11/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.11/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.11/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.11/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (macOS)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`

--- a/versioned_docs/version-1.11/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.11/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.11/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.11/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.11/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.11/ui/preferences/wsl/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (Windows)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel

--- a/versioned_docs/version-1.11/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.11/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.11/ui/snapshots.md
+++ b/versioned_docs/version-1.11/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.11/ui/troubleshooting.md
+++ b/versioned_docs/version-1.11/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.12/faq.md
+++ b/versioned_docs/version-1.12/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.12/getting-started/deployment.md
+++ b/versioned_docs/version-1.12/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.12/getting-started/installation.md
+++ b/versioned_docs/version-1.12/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.12/getting-started/introduction.md
+++ b/versioned_docs/version-1.12/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.12/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.12/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.12/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.12/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](https://docs.rancherdesktop.io/getting-started/deployment).
 
 :::note

--- a/versioned_docs/version-1.12/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.12/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.12/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.12/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.12/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.12/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.12/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.12/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.12/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.12/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.12/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.12/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.12/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.12/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.12/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.12/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.12/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.12/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.12/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.12/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.12/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.12/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.12/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.12/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.12/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.12/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.12/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.12/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.12/references/architecture.md
+++ b/versioned_docs/version-1.12/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.12/references/bundled-utilities.md
+++ b/versioned_docs/version-1.12/references/bundled-utilities.md
@@ -11,10 +11,6 @@ import Version110 from '../bundled-utilities-version-info/v1.10.0.md';
 import Version111 from '../bundled-utilities-version-info/v1.11.0.md';
 import Version112 from '../bundled-utilities-version-info/v1.12.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.12/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.12/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.12/troubleshooting-tips.md
+++ b/versioned_docs/version-1.12/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.12/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.12/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.12/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.12/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.12/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.12/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.12/ui/containers.md
+++ b/versioned_docs/version-1.12/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.12/ui/diagnostics.md
+++ b/versioned_docs/version-1.12/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.12/ui/extensions.md
+++ b/versioned_docs/version-1.12/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.12/ui/general.md
+++ b/versioned_docs/version-1.12/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.12/ui/images.md
+++ b/versioned_docs/version-1.12/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.12/ui/port-forwarding.md
+++ b/versioned_docs/version-1.12/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.12/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.12/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.12/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.12/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.12/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.12/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.12/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.12/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.12/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.12/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.12/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.12/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (macOS)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`

--- a/versioned_docs/version-1.12/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.12/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.12/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.12/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (Windows)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel

--- a/versioned_docs/version-1.12/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.12/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.12/ui/snapshots.md
+++ b/versioned_docs/version-1.12/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.12/ui/troubleshooting.md
+++ b/versioned_docs/version-1.12/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.13/faq.md
+++ b/versioned_docs/version-1.13/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.13/getting-started/deployment.md
+++ b/versioned_docs/version-1.13/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.13/getting-started/installation.md
+++ b/versioned_docs/version-1.13/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.13/getting-started/introduction.md
+++ b/versioned_docs/version-1.13/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.13/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.13/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.13/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.13/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.13/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.13/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.13/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.13/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.13/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.13/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.13/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.13/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.13/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.13/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.13/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.13/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.13/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.13/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.13/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.13/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.13/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.13/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.13/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.13/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.13/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.13/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.13/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.13/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.13/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.13/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.13/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.13/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.13/references/architecture.md
+++ b/versioned_docs/version-1.13/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.13/references/bundled-utilities.md
+++ b/versioned_docs/version-1.13/references/bundled-utilities.md
@@ -12,10 +12,6 @@ import Version111 from '../bundled-utilities-version-info/v1.11.0.md';
 import Version112 from '../bundled-utilities-version-info/v1.12.0.md';
 import Version113 from '../bundled-utilities-version-info/v1.13.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.13/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.13/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.13/troubleshooting-tips.md
+++ b/versioned_docs/version-1.13/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.13/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.13/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.13/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.13/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.13/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.13/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.13/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.13/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.13/ui/containers.md
+++ b/versioned_docs/version-1.13/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.13/ui/diagnostics.md
+++ b/versioned_docs/version-1.13/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.13/ui/extensions.md
+++ b/versioned_docs/version-1.13/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.13/ui/general.md
+++ b/versioned_docs/version-1.13/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.13/ui/images.md
+++ b/versioned_docs/version-1.13/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.13/ui/port-forwarding.md
+++ b/versioned_docs/version-1.13/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.13/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.13/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.13/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.13/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.13/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.13/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.13/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.13/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.13/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.13/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.13/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.13/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (macOS)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`

--- a/versioned_docs/version-1.13/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.13/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.13/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.13/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.13/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.13/ui/preferences/wsl/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (Windows)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel

--- a/versioned_docs/version-1.13/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.13/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.13/ui/snapshots.md
+++ b/versioned_docs/version-1.13/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.13/ui/troubleshooting.md
+++ b/versioned_docs/version-1.13/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.14/faq.md
+++ b/versioned_docs/version-1.14/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.14/getting-started/deployment.md
+++ b/versioned_docs/version-1.14/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.14/getting-started/installation.md
+++ b/versioned_docs/version-1.14/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.14/getting-started/introduction.md
+++ b/versioned_docs/version-1.14/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.14/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.14/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.14/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.14/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.14/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.14/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.14/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.14/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.14/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.14/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.14/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.14/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.14/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.14/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.14/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.14/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.14/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.14/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.14/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.14/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.14/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.14/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.14/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.14/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.14/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.14/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.14/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.14/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.14/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.14/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.14/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.14/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.14/references/architecture.md
+++ b/versioned_docs/version-1.14/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.14/references/bundled-utilities.md
+++ b/versioned_docs/version-1.14/references/bundled-utilities.md
@@ -13,10 +13,6 @@ import Version112 from '../bundled-utilities-version-info/v1.12.0.md';
 import Version113 from '../bundled-utilities-version-info/v1.13.0.md';
 import Version114 from '../bundled-utilities-version-info/v1.14.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.14/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.14/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.14/troubleshooting-tips.md
+++ b/versioned_docs/version-1.14/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.14/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.14/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.14/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.14/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.14/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.14/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.14/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.14/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.14/ui/containers.md
+++ b/versioned_docs/version-1.14/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.14/ui/diagnostics.md
+++ b/versioned_docs/version-1.14/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.14/ui/extensions.md
+++ b/versioned_docs/version-1.14/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.14/ui/general.md
+++ b/versioned_docs/version-1.14/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.14/ui/images.md
+++ b/versioned_docs/version-1.14/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.14/ui/port-forwarding.md
+++ b/versioned_docs/version-1.14/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.14/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.14/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.14/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.14/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.14/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.14/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.14/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.14/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.14/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.14/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.14/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.14/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/network.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (macOS)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabNetwork.png)
 
 ### Enable `socket-vmnet`

--- a/versioned_docs/version-1.14/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.14/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.14/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.14/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.14/ui/preferences/wsl/network.md
+++ b/versioned_docs/version-1.14/ui/preferences/wsl/network.md
@@ -3,9 +3,6 @@ sidebar_label: Network
 title: Network (Windows)
 ---
 
-<head>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabNetwork.png)
 
 ### Networking Tunnel

--- a/versioned_docs/version-1.14/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.14/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.14/ui/snapshots.md
+++ b/versioned_docs/version-1.14/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.14/ui/troubleshooting.md
+++ b/versioned_docs/version-1.14/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.15/faq.md
+++ b/versioned_docs/version-1.15/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.15/getting-started/deployment.md
+++ b/versioned_docs/version-1.15/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.15/getting-started/installation.md
+++ b/versioned_docs/version-1.15/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.15/getting-started/introduction.md
+++ b/versioned_docs/version-1.15/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.15/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.15/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.15/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.15/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.15/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.15/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.15/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.15/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.15/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.15/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.15/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.15/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.15/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.15/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.15/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.15/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.15/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.15/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.15/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.15/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.15/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.15/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.15/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.15/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.15/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.15/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.15/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.15/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.15/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.15/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.15/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.15/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.15/references/architecture.md
+++ b/versioned_docs/version-1.15/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.15/references/bundled-utilities.md
+++ b/versioned_docs/version-1.15/references/bundled-utilities.md
@@ -14,10 +14,6 @@ import Version113 from '../bundled-utilities-version-info/v1.13.0.md';
 import Version114 from '../bundled-utilities-version-info/v1.14.0.md';
 import Version115 from '../bundled-utilities-version-info/v1.15.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions                                    |

--- a/versioned_docs/version-1.15/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.15/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.15/troubleshooting-tips.md
+++ b/versioned_docs/version-1.15/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.15/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.15/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.15/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.15/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.15/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.15/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.15/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.15/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.15/ui/containers.md
+++ b/versioned_docs/version-1.15/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.15/ui/diagnostics.md
+++ b/versioned_docs/version-1.15/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.15/ui/extensions.md
+++ b/versioned_docs/version-1.15/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.15/ui/general.md
+++ b/versioned_docs/version-1.15/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.15/ui/images.md
+++ b/versioned_docs/version-1.15/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.15/ui/port-forwarding.md
+++ b/versioned_docs/version-1.15/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.15/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.15/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.15/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.15/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.15/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.15/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.15/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.15/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.15/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.15/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.15/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.15/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.15/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.15/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.15/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.15/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.15/ui/snapshots.md
+++ b/versioned_docs/version-1.15/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.15/ui/troubleshooting.md
+++ b/versioned_docs/version-1.15/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.16/faq.md
+++ b/versioned_docs/version-1.16/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.16/getting-started/deployment.md
+++ b/versioned_docs/version-1.16/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.16/getting-started/installation.md
+++ b/versioned_docs/version-1.16/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.16/getting-started/introduction.md
+++ b/versioned_docs/version-1.16/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.16/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.16/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.16/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.16/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.16/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.16/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.16/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.16/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.16/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.16/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.16/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.16/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.16/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.16/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.16/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.16/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.16/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.16/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.16/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.16/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.16/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.16/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.16/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.16/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.16/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.16/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.16/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.16/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.16/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.16/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.16/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.16/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.16/references/architecture.md
+++ b/versioned_docs/version-1.16/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.16/references/bundled-utilities.md
+++ b/versioned_docs/version-1.16/references/bundled-utilities.md
@@ -15,10 +15,6 @@ import Version114 from '../bundled-utilities-version-info/v1.14.0.md';
 import Version115 from '../bundled-utilities-version-info/v1.15.0.md';
 import Version116 from '../bundled-utilities-version-info/v1.16.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions                                    |

--- a/versioned_docs/version-1.16/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.16/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.16/troubleshooting-tips.md
+++ b/versioned_docs/version-1.16/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.16/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.16/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.16/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.16/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.16/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.16/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.16/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.16/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.16/ui/containers.md
+++ b/versioned_docs/version-1.16/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.16/ui/diagnostics.md
+++ b/versioned_docs/version-1.16/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.16/ui/extensions.md
+++ b/versioned_docs/version-1.16/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.16/ui/general.md
+++ b/versioned_docs/version-1.16/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.16/ui/images.md
+++ b/versioned_docs/version-1.16/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.16/ui/port-forwarding.md
+++ b/versioned_docs/version-1.16/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.16/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.16/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.16/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.16/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.16/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.16/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.16/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.16/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.16/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.16/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.16/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.16/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.16/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.16/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.16/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.16/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.16/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.16/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.16/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.16/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.16/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.16/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.16/ui/snapshots.md
+++ b/versioned_docs/version-1.16/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.16/ui/troubleshooting.md
+++ b/versioned_docs/version-1.16/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.17/faq.md
+++ b/versioned_docs/version-1.17/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.17/getting-started/deployment.md
+++ b/versioned_docs/version-1.17/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.17/getting-started/installation.md
+++ b/versioned_docs/version-1.17/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.17/getting-started/introduction.md
+++ b/versioned_docs/version-1.17/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.17/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.17/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.17/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.17/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.17/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.17/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.17/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.17/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.17/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.17/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.17/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.17/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.17/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.17/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.17/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.17/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.17/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.17/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.17/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.17/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.17/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.17/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.17/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.17/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.17/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.17/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.17/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.17/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.17/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.17/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.17/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.17/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.17/references/architecture.md
+++ b/versioned_docs/version-1.17/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.17/references/bundled-utilities.md
+++ b/versioned_docs/version-1.17/references/bundled-utilities.md
@@ -16,10 +16,6 @@ import Version115 from '../bundled-utilities-version-info/v1.15.0.md';
 import Version116 from '../bundled-utilities-version-info/v1.16.0.md';
 import Version117 from '../bundled-utilities-version-info/v1.17.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions                                    |

--- a/versioned_docs/version-1.17/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.17/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.17/troubleshooting-tips.md
+++ b/versioned_docs/version-1.17/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.17/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.17/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.17/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.17/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.17/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.17/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.17/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.17/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.17/ui/containers.md
+++ b/versioned_docs/version-1.17/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.17/ui/diagnostics.md
+++ b/versioned_docs/version-1.17/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.17/ui/extensions.md
+++ b/versioned_docs/version-1.17/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.17/ui/general.md
+++ b/versioned_docs/version-1.17/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.17/ui/images.md
+++ b/versioned_docs/version-1.17/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.17/ui/port-forwarding.md
+++ b/versioned_docs/version-1.17/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.17/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.17/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.17/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.17/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.17/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.17/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.17/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.17/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.17/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.17/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.17/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.17/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.17/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.17/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.17/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.17/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.17/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.17/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.17/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.17/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.17/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.17/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.17/ui/snapshots.md
+++ b/versioned_docs/version-1.17/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.17/ui/troubleshooting.md
+++ b/versioned_docs/version-1.17/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.18/faq.md
+++ b/versioned_docs/version-1.18/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.18/getting-started/deployment.md
+++ b/versioned_docs/version-1.18/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.18/getting-started/installation.md
+++ b/versioned_docs/version-1.18/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.18/getting-started/introduction.md
+++ b/versioned_docs/version-1.18/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.18/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.18/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.18/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.18/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.18/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.18/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.18/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.18/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.18/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.18/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.18/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.18/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.18/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.18/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.18/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.18/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.18/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.18/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.18/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.18/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.18/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.18/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.18/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.18/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.18/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.18/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.18/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.18/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.18/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.18/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.18/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.18/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.18/references/architecture.md
+++ b/versioned_docs/version-1.18/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.18/references/bundled-utilities.md
+++ b/versioned_docs/version-1.18/references/bundled-utilities.md
@@ -17,10 +17,6 @@ import Version116 from '../bundled-utilities-version-info/v1.16.0.md';
 import Version117 from '../bundled-utilities-version-info/v1.17.0.md';
 import Version118 from '../bundled-utilities-version-info/v1.18.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions                                    |

--- a/versioned_docs/version-1.18/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.18/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.18/troubleshooting-tips.md
+++ b/versioned_docs/version-1.18/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.18/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.18/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.18/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.18/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.18/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.18/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.18/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.18/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.18/ui/containers.md
+++ b/versioned_docs/version-1.18/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.18/ui/diagnostics.md
+++ b/versioned_docs/version-1.18/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.18/ui/extensions.md
+++ b/versioned_docs/version-1.18/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.18/ui/general.md
+++ b/versioned_docs/version-1.18/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.18/ui/images.md
+++ b/versioned_docs/version-1.18/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.18/ui/port-forwarding.md
+++ b/versioned_docs/version-1.18/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.18/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.18/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.18/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.18/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.18/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.18/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.18/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.18/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.18/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.18/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.18/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.18/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.18/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.18/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.18/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.18/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.18/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.18/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.18/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.18/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.18/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.18/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.18/ui/snapshots.md
+++ b/versioned_docs/version-1.18/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.18/ui/troubleshooting.md
+++ b/versioned_docs/version-1.18/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.19/faq.md
+++ b/versioned_docs/version-1.19/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.19/getting-started/deployment.md
+++ b/versioned_docs/version-1.19/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.19/getting-started/installation.md
+++ b/versioned_docs/version-1.19/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.19/getting-started/introduction.md
+++ b/versioned_docs/version-1.19/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.19/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.19/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.19/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.19/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.19/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.19/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.19/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.19/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.19/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.19/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.19/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.19/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.19/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.19/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.19/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.19/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.19/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.19/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.19/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.19/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.19/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.19/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.19/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.19/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.19/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.19/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.19/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.19/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.19/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.19/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.19/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.19/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.19/references/architecture.md
+++ b/versioned_docs/version-1.19/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.19/references/bundled-utilities.md
+++ b/versioned_docs/version-1.19/references/bundled-utilities.md
@@ -18,10 +18,6 @@ import Version117 from '../bundled-utilities-version-info/v1.17.0.md';
 import Version118 from '../bundled-utilities-version-info/v1.18.0.md';
 import Version119 from '../bundled-utilities-version-info/v1.19.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions                                    |

--- a/versioned_docs/version-1.19/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.19/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.19/troubleshooting-tips.md
+++ b/versioned_docs/version-1.19/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.19/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.19/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.19/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.19/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.19/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.19/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.19/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.19/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.19/ui/containers.md
+++ b/versioned_docs/version-1.19/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <!--- Insert S3 Image Here Once Uploaded -->

--- a/versioned_docs/version-1.19/ui/diagnostics.md
+++ b/versioned_docs/version-1.19/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.19/ui/extensions.md
+++ b/versioned_docs/version-1.19/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.19/ui/general.md
+++ b/versioned_docs/version-1.19/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.19/ui/images.md
+++ b/versioned_docs/version-1.19/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.19/ui/port-forwarding.md
+++ b/versioned_docs/version-1.19/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.19/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.19/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.19/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.19/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.19/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.19/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.19/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.19/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.19/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.19/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.19/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.19/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.19/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.19/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### QEMU
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation.png)

--- a/versioned_docs/version-1.19/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.19/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.19/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.19/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.19/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.19/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.19/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.19/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.19/ui/snapshots.md
+++ b/versioned_docs/version-1.19/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.19/ui/troubleshooting.md
+++ b/versioned_docs/version-1.19/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/faq.md
+++ b/versioned_docs/version-1.20/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.20/getting-started/deployment.md
+++ b/versioned_docs/version-1.20/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.20/getting-started/installation.md
+++ b/versioned_docs/version-1.20/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.20/getting-started/introduction.md
+++ b/versioned_docs/version-1.20/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.20/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.20/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.20/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.20/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.20/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.20/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.20/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.20/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.20/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.20/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.20/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.20/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.20/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.20/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.20/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.20/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.20/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.20/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.20/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.20/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.20/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.20/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.20/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.20/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.20/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.20/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.20/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.20/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.20/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.20/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.20/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.20/references/architecture.md
+++ b/versioned_docs/version-1.20/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.20/references/bundled-utilities.md
+++ b/versioned_docs/version-1.20/references/bundled-utilities.md
@@ -6,10 +6,6 @@ import Version118 from '../bundled-utilities-version-info/v1.18.0.md';
 import Version119 from '../bundled-utilities-version-info/v1.19.0.md';
 import Version120 from '../bundled-utilities-version-info/v1.20.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions                                    |

--- a/versioned_docs/version-1.20/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.20/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.20/troubleshooting-tips.md
+++ b/versioned_docs/version-1.20/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.20/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.20/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.20/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.20/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.20/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.20/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.20/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.20/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.20/ui/containers.md
+++ b/versioned_docs/version-1.20/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/ui/diagnostics.md
+++ b/versioned_docs/version-1.20/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.20/ui/extensions.md
+++ b/versioned_docs/version-1.20/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.20/ui/general.md
+++ b/versioned_docs/version-1.20/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.20/ui/images.md
+++ b/versioned_docs/version-1.20/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/ui/port-forwarding.md
+++ b/versioned_docs/version-1.20/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.20/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.20/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.20/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.20/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.20/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.20/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.20/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.20/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.20/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.20/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.20/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.20/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### VZ
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)

--- a/versioned_docs/version-1.20/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.20/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.20/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.20/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.20/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.20/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.20/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.20/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.20/ui/snapshots.md
+++ b/versioned_docs/version-1.20/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/ui/troubleshooting.md
+++ b/versioned_docs/version-1.20/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.20/ui/volumes.md
+++ b/versioned_docs/version-1.20/ui/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/faq.md
+++ b/versioned_docs/version-1.21/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.21/getting-started/deployment.md
+++ b/versioned_docs/version-1.21/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.21/getting-started/installation.md
+++ b/versioned_docs/version-1.21/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.21/getting-started/introduction.md
+++ b/versioned_docs/version-1.21/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.21/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.21/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.21/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.21/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.21/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.21/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.21/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.21/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.21/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.21/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.21/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.21/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.21/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.21/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.21/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.21/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.21/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.21/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.21/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.21/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.21/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.21/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.21/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.21/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.21/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.21/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.21/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.21/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.21/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.21/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.21/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.21/references/architecture.md
+++ b/versioned_docs/version-1.21/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.21/references/bundled-utilities.md
+++ b/versioned_docs/version-1.21/references/bundled-utilities.md
@@ -6,10 +6,6 @@ import Version119 from '../bundled-utilities-version-info/v1.19.0.md';
 import Version120 from '../bundled-utilities-version-info/v1.20.0.md';
 import Version121 from '../bundled-utilities-version-info/v1.21.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.21/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.21/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.21/troubleshooting-tips.md
+++ b/versioned_docs/version-1.21/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.21/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.21/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.21/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.21/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.21/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.21/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.21/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.21/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.21/ui/containers.md
+++ b/versioned_docs/version-1.21/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/ui/diagnostics.md
+++ b/versioned_docs/version-1.21/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.21/ui/extensions.md
+++ b/versioned_docs/version-1.21/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.21/ui/general.md
+++ b/versioned_docs/version-1.21/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.21/ui/images.md
+++ b/versioned_docs/version-1.21/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/ui/port-forwarding.md
+++ b/versioned_docs/version-1.21/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.21/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.21/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.21/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.21/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.21/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.21/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.21/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.21/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.21/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.21/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.21/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.21/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### VZ
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)

--- a/versioned_docs/version-1.21/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.21/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.21/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.21/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.21/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.21/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.21/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.21/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.21/ui/snapshots.md
+++ b/versioned_docs/version-1.21/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/ui/troubleshooting.md
+++ b/versioned_docs/version-1.21/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.21/ui/volumes.md
+++ b/versioned_docs/version-1.21/ui/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/faq.md
+++ b/versioned_docs/version-1.22/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.22/getting-started/deployment.md
+++ b/versioned_docs/version-1.22/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-1.22/getting-started/installation.md
+++ b/versioned_docs/version-1.22/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.22/getting-started/introduction.md
+++ b/versioned_docs/version-1.22/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-1.22/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.22/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.22/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-1.22/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-1.22/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.22/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.22/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.22/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-1.22/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-1.22/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-1.22/how-to-guides/migrating-images.md
+++ b/versioned_docs/version-1.22/how-to-guides/migrating-images.md
@@ -2,10 +2,6 @@
 title: Migrating Moby Images Between Storage Drivers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/migrating-images"/>
-</head>
-
 Rancher Desktop stores images using two storage drivers when running the moby (docker) container engine: the **classic storage driver** and the **containerd snapshotter**. This page explains why images become hidden and how to access them.
 
 ## Background

--- a/versioned_docs/version-1.22/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.22/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.22/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.22/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.22/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.22/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.22/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-1.22/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.22/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.22/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.22/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.22/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-1.22/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-1.22/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.22/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.22/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-1.22/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be used with [Testcontainers](https://testcontainers.com/) to execute ephemeral tests and containers that work inside Docker. This guide demonstrates the use of Testcontainers with a sample repository.

--- a/versioned_docs/version-1.22/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.22/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.22/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.22/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.22/references/architecture.md
+++ b/versioned_docs/version-1.22/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.22/references/bundled-utilities.md
+++ b/versioned_docs/version-1.22/references/bundled-utilities.md
@@ -6,10 +6,6 @@ import Version120 from '../bundled-utilities-version-info/v1.20.0.md';
 import Version121 from '../bundled-utilities-version-info/v1.21.0.md';
 import Version122 from '../bundled-utilities-version-info/v1.22.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.22/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.22/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.22/troubleshooting-tips.md
+++ b/versioned_docs/version-1.22/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-1.22/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-1.22/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-1.22/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.22/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.22/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.22/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.22/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-1.22/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-1.22/ui/containers.md
+++ b/versioned_docs/version-1.22/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/ui/diagnostics.md
+++ b/versioned_docs/version-1.22/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.22/ui/extensions.md
+++ b/versioned_docs/version-1.22/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-1.22/ui/general.md
+++ b/versioned_docs/version-1.22/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-1.22/ui/images.md
+++ b/versioned_docs/version-1.22/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/ui/port-forwarding.md
+++ b/versioned_docs/version-1.22/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-1.22/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-1.22/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.22/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-1.22/ui/preferences/application/general.md
+++ b/versioned_docs/version-1.22/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-1.22/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-1.22/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-1.22/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-1.22/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-1.22/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-1.22/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-1.22/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### VZ
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)

--- a/versioned_docs/version-1.22/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-1.22/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-1.22/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-1.22/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-1.22/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-1.22/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-1.22/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-1.22/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-1.22/ui/snapshots.md
+++ b/versioned_docs/version-1.22/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/ui/troubleshooting.md
+++ b/versioned_docs/version-1.22/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.22/ui/volumes.md
+++ b/versioned_docs/version-1.22/ui/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.6/faq.md
+++ b/versioned_docs/version-1.6/faq.md
@@ -2,10 +2,6 @@
 title: FAQ
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.6/getting-started/installation.md
+++ b/versioned_docs/version-1.6/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.6/getting-started/introduction.md
+++ b/versioned_docs/version-1.6/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](../img/intro/intro.png)

--- a/versioned_docs/version-1.6/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.6/how-to-guides/create-multi-node-cluster.md
@@ -5,10 +5,6 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.6/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.6/how-to-guides/hello-world-example.md
@@ -5,10 +5,6 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.6/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.6/how-to-guides/increasing-open-file-limit.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.6/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.6/how-to-guides/provisioning-scripts.md
@@ -5,10 +5,6 @@ title: Provisioning Scripts
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/versioned_docs/version-1.6/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.6/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,10 +5,6 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.6/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.6/how-to-guides/running-air-gapped.md
@@ -5,10 +5,6 @@ title: Running When Offline
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.6/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.6/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,10 +5,6 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.6/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.6/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,10 +5,6 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.6/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.6/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.6/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.6/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.6/references/architecture.md
+++ b/versioned_docs/version-1.6/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.6/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.6/references/rdctl-command-reference.md
@@ -5,10 +5,6 @@ title: rdctl Command Reference
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
  
 **:warning: As the current version of `rdctl` is experimental, all subcommands names, their arguments, and their output are still subjected to change.**

--- a/versioned_docs/version-1.6/troubleshooting-tips.md
+++ b/versioned_docs/version-1.6/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?

--- a/versioned_docs/version-1.6/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.6/tutorials/working-with-containers.md
@@ -5,10 +5,6 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.6/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.6/tutorials/working-with-images.md
@@ -5,10 +5,6 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.7/faq.md
+++ b/versioned_docs/version-1.7/faq.md
@@ -2,10 +2,6 @@
 title: FAQ
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.7/getting-started/installation.md
+++ b/versioned_docs/version-1.7/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.7/getting-started/introduction.md
+++ b/versioned_docs/version-1.7/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](../img/intro/intro.png)

--- a/versioned_docs/version-1.7/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.7/how-to-guides/create-multi-node-cluster.md
@@ -5,10 +5,6 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.7/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.7/how-to-guides/hello-world-example.md
@@ -5,10 +5,6 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.7/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.7/how-to-guides/increasing-open-file-limit.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.7/how-to-guides/provisioning-scripts.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/versioned_docs/version-1.7/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.7/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,10 +5,6 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.7/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.7/how-to-guides/running-air-gapped.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.7/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.7/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,10 +5,6 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.7/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.7/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,10 +5,6 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.7/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.7/how-to-guides/transfer-container-images.md
@@ -5,10 +5,6 @@ title: Transfer Container Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.7/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.7/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.7/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.7/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.7/references/architecture.md
+++ b/versioned_docs/version-1.7/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.7/references/bundled-utilities.md
+++ b/versioned_docs/version-1.7/references/bundled-utilities.md
@@ -5,10 +5,6 @@ title: Bundled Utilities
 import Version160 from '../bundled-utilities-version-info/v1.6.0.md';
 import Version170 from '../bundled-utilities-version-info/v1.7.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.7/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.7/references/rdctl-command-reference.md
@@ -5,10 +5,6 @@ title: "Command Reference: rdctl"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
  
 **:warning: As the current version of `rdctl` is experimental, all subcommands names, their arguments, and their output are still subjected to change.**

--- a/versioned_docs/version-1.7/troubleshooting-tips.md
+++ b/versioned_docs/version-1.7/troubleshooting-tips.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 
 #### Q: Why do I not see my WSL distro under Rancher Desktop's WSL Integration page?

--- a/versioned_docs/version-1.7/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.7/tutorials/working-with-containers.md
@@ -5,10 +5,6 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.7/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.7/tutorials/working-with-images.md
@@ -5,10 +5,6 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.7/ui/diagnostics.md
+++ b/versioned_docs/version-1.7/ui/diagnostics.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 **Note:** Rancher Desktop *doesn't* send the diagnostics data to any remote server for processing or storing.
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-1.7/ui/general.md
+++ b/versioned_docs/version-1.7/ui/general.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.7/ui/images.md
+++ b/versioned_docs/version-1.7/ui/images.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 The **Images** tab, allows you to manage the images on your virtual machine.
 
 To manage your images using nerdctl instead, refer to the [Images](../tutorials/working-with-images.md) section.

--- a/versioned_docs/version-1.7/ui/port-forwarding.md
+++ b/versioned_docs/version-1.7/ui/port-forwarding.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 To forward a port:
 
 1. Find the service and click **Forward**.

--- a/versioned_docs/version-1.7/ui/troubleshooting.md
+++ b/versioned_docs/version-1.7/ui/troubleshooting.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 ### Show Logs
 
 Use this option to open the folder containing all Rancher Desktop log files.

--- a/versioned_docs/version-1.8/faq.md
+++ b/versioned_docs/version-1.8/faq.md
@@ -2,10 +2,6 @@
 title: FAQ
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.8/getting-started/deployment.md
+++ b/versioned_docs/version-1.8/getting-started/deployment.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 Deployment profiles provide 2 features:
 
 * "Defaults" provide preference values that are applied on first run (or after a factory reset).

--- a/versioned_docs/version-1.8/getting-started/installation.md
+++ b/versioned_docs/version-1.8/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.8/getting-started/introduction.md
+++ b/versioned_docs/version-1.8/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.
 
 ![](../img/intro/intro.png)

--- a/versioned_docs/version-1.8/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.8/how-to-guides/create-multi-node-cluster.md
@@ -5,10 +5,6 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.8/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.8/how-to-guides/hello-world-example.md
@@ -5,10 +5,6 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.8/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.8/how-to-guides/increasing-open-file-limit.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.8/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.8/how-to-guides/provisioning-scripts.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.
 
 ## macOS & Linux

--- a/versioned_docs/version-1.8/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.8/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,10 +5,6 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.8/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.8/how-to-guides/running-air-gapped.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.8/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.8/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,10 +5,6 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.8/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.8/how-to-guides/skaffold-and-rancher-desktop.md
@@ -5,10 +5,6 @@ title: Skaffold and Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.8/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.8/how-to-guides/transfer-container-images.md
@@ -5,10 +5,6 @@ title: Transfer Container Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.8/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.8/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.8/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.8/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.8/references/architecture.md
+++ b/versioned_docs/version-1.8/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.8/references/bundled-utilities.md
+++ b/versioned_docs/version-1.8/references/bundled-utilities.md
@@ -6,10 +6,6 @@ import Version160 from '../bundled-utilities-version-info/v1.6.0.md';
 import Version170 from '../bundled-utilities-version-info/v1.7.0.md';
 import Version180 from '../bundled-utilities-version-info/v1.8.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.8/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.8/references/rdctl-command-reference.md
@@ -5,10 +5,6 @@ title: "Command Reference: rdctl"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
  
 **:warning: As the current version of `rdctl` is experimental, all subcommands names, their arguments, and their output are still subjected to change.**

--- a/versioned_docs/version-1.8/troubleshooting-tips.md
+++ b/versioned_docs/version-1.8/troubleshooting-tips.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 
 #### Q: How can I fix the Docker error when starting a container using the VS Code dev-containers extension with version >`v0.266`?

--- a/versioned_docs/version-1.8/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.8/tutorials/working-with-containers.md
@@ -5,10 +5,6 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.8/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.8/tutorials/working-with-images.md
@@ -5,10 +5,6 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.8/ui/diagnostics.md
+++ b/versioned_docs/version-1.8/ui/diagnostics.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.
 
 **Note:** Rancher Desktop *doesn't* send the diagnostics data to any remote server for processing or storing.

--- a/versioned_docs/version-1.8/ui/general.md
+++ b/versioned_docs/version-1.8/ui/general.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.8/ui/images.md
+++ b/versioned_docs/version-1.8/ui/images.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 The **Images** tab, allows you to manage the images on your virtual machine.
 
 To manage your images using nerdctl instead, refer to the [Images](../tutorials/working-with-images.md) section.

--- a/versioned_docs/version-1.8/ui/port-forwarding.md
+++ b/versioned_docs/version-1.8/ui/port-forwarding.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 

--- a/versioned_docs/version-1.8/ui/troubleshooting.md
+++ b/versioned_docs/version-1.8/ui/troubleshooting.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 

--- a/versioned_docs/version-1.9/faq.md
+++ b/versioned_docs/version-1.9/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-1.9/getting-started/deployment.md
+++ b/versioned_docs/version-1.9/getting-started/deployment.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 Deployment profiles provide 2 features:
 
 * "Defaults" provide preference values that are applied on first run (or after a factory reset).

--- a/versioned_docs/version-1.9/getting-started/installation.md
+++ b/versioned_docs/version-1.9/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-1.9/getting-started/introduction.md
+++ b/versioned_docs/version-1.9/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';

--- a/versioned_docs/version-1.9/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-1.9/how-to-guides/create-multi-node-cluster.md
@@ -5,10 +5,6 @@ title: Create a Multi-Node Cluster with k3d
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-1.9/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-1.9/how-to-guides/hello-world-example.md
@@ -5,10 +5,6 @@ title: Hello World Example
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-1.9/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-1.9/how-to-guides/increasing-open-file-limit.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.
 
 ## macOS & Linux Steps

--- a/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-1.9/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-1.9/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-1.9/how-to-guides/rancher-on-rancher-desktop.md
@@ -5,10 +5,6 @@ title: Rancher on Rancher Desktop
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-1.9/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-1.9/how-to-guides/running-air-gapped.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements
 and possible problems when running in air-gapped mode.
 

--- a/versioned_docs/version-1.9/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-1.9/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -5,10 +5,6 @@ title: Setup NGINX Ingress Controller
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-1.9/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-1.9/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-1.9/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-1.9/how-to-guides/transfer-container-images.md
@@ -5,10 +5,6 @@ title: Transfer Container Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-1.9/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-1.9/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-1.9/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-1.9/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-1.9/references/architecture.md
+++ b/versioned_docs/version-1.9/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-1.9/references/bundled-utilities.md
+++ b/versioned_docs/version-1.9/references/bundled-utilities.md
@@ -8,10 +8,6 @@ import Version180 from '../bundled-utilities-version-info/v1.8.0.md';
 import Version190 from '../bundled-utilities-version-info/v1.9.0.md';
 import Version191 from '../bundled-utilities-version-info/v1.9.1.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-1.9/references/rdctl-command-reference.md
+++ b/versioned_docs/version-1.9/references/rdctl-command-reference.md
@@ -5,10 +5,6 @@ title: "Command Reference: rdctl"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-1.9/troubleshooting-tips.md
+++ b/versioned_docs/version-1.9/troubleshooting-tips.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.
 
 ### API

--- a/versioned_docs/version-1.9/tutorials/working-with-containers.md
+++ b/versioned_docs/version-1.9/tutorials/working-with-containers.md
@@ -5,10 +5,6 @@ title: Working with Containers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-1.9/tutorials/working-with-images.md
+++ b/versioned_docs/version-1.9/tutorials/working-with-images.md
@@ -5,10 +5,6 @@ title: Working with Images
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-1.9/ui/diagnostics.md
+++ b/versioned_docs/version-1.9/ui/diagnostics.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.
 
 **Note:** Rancher Desktop *doesn't* send the diagnostics data to any remote server for processing or storing.

--- a/versioned_docs/version-1.9/ui/extensions.md
+++ b/versioned_docs/version-1.9/ui/extensions.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 ### Catalog
 
 The **Catalog** tab acts as a marketplace for available Rancher Desktop Extensions. Users can view and click on extensions for further description and the ability to install extensions directly through the UI.

--- a/versioned_docs/version-1.9/ui/general.md
+++ b/versioned_docs/version-1.9/ui/general.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-1.9/ui/images.md
+++ b/versioned_docs/version-1.9/ui/images.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 The **Images** tab, allows you to manage the images on your virtual machine.
 
 To manage your images using nerdctl instead, refer to the [Images](../tutorials/working-with-images.md) section.

--- a/versioned_docs/version-1.9/ui/port-forwarding.md
+++ b/versioned_docs/version-1.9/ui/port-forwarding.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 

--- a/versioned_docs/version-1.9/ui/troubleshooting.md
+++ b/versioned_docs/version-1.9/ui/troubleshooting.md
@@ -7,10 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Windows">
 

--- a/versioned_docs/version-latest/faq.md
+++ b/versioned_docs/version-latest/faq.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/faq"/>
-</head>
-
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher Desktop.
 
 #### **Q: Is Rancher Desktop a desktop version of Rancher?**

--- a/versioned_docs/version-latest/getting-started/deployment.md
+++ b/versioned_docs/version-latest/getting-started/deployment.md
@@ -2,10 +2,6 @@
 title: Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/deployment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Deployment profiles provide 2 features:

--- a/versioned_docs/version-latest/getting-started/installation.md
+++ b/versioned_docs/version-latest/getting-started/installation.md
@@ -2,10 +2,6 @@
 title: Installation
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/getting-started/installation"/>
-</head>
-
 Rancher Desktop is delivered as a desktop application. You can download it from
 the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 

--- a/versioned_docs/version-latest/getting-started/introduction.md
+++ b/versioned_docs/version-latest/getting-started/introduction.md
@@ -3,10 +3,6 @@ title: Introduction
 slug: /
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop is an app that provides container management and Kubernetes on the desktop. It is available for Mac (both on Intel and Apple Silicon), Windows, and Linux.

--- a/versioned_docs/version-latest/how-to-guides/create-multi-node-cluster.md
+++ b/versioned_docs/version-latest/how-to-guides/create-multi-node-cluster.md
@@ -2,10 +2,6 @@
 title: Create a Multi-Node Cluster with k3d
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/create-multi-node-cluster"/>
-</head>
-
 Rancher Desktop provides a **single cluster with single node** setup, which is adequate for most local development scenarios. However, there are use cases where, the ability to create a multi node cluster or spin up multiple clusters with flexibilty to switch between clusters is required. Eventhough Rancher Desktop doesn't have in-built multi node/cluster functionality, you can use [k3d](https://k3d.io) with Rancher Desktop to accomplish the same. k3d is a lightweight wrapper to run k3s (a minimal Kubernetes distribution, which is used by Rancher Desktop as well) in docker. k3d makes it very easy to create single- and multi-node k3s clusters in docker, e.g. for local development on Kubernetes.
 
 ### Steps to spin up a multi-node cluster

--- a/versioned_docs/version-latest/how-to-guides/generating-deployment-profiles.md
+++ b/versioned_docs/version-latest/how-to-guides/generating-deployment-profiles.md
@@ -2,10 +2,6 @@
 title: Generating Deployment Profiles
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 Deployment Profiles are a way of both providing first-time default settings for Rancher Desktop, and locking down any or all of the application settings. The purpose of this guide is to demonstrate how to create deployment profiles. General information about deployment profiles are further detailed in [Getting Started > Deployment Profiles](../getting-started/deployment.md).
 
 :::note

--- a/versioned_docs/version-latest/how-to-guides/hello-world-example.md
+++ b/versioned_docs/version-latest/how-to-guides/hello-world-example.md
@@ -2,10 +2,6 @@
 title: Hello World Example
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/hello-world-example"/>
-</head>
-
 This tutorial will demonstrate how to get started with Rancher Desktop by pushing an app to a local Kubernetes cluster.
 
 Rancher Desktop works with two container engines, [containerd](https://containerd.io/) and [Moby](https://mobyproject.org/), the open-sourced components of the Docker ecosystem. For `nerdctl`, use the **containerd** runtime. For `docker`, use the **dockerd(moby)** runtime.

--- a/versioned_docs/version-latest/how-to-guides/increasing-open-file-limit.md
+++ b/versioned_docs/version-latest/how-to-guides/increasing-open-file-limit.md
@@ -2,10 +2,6 @@
 title: Increasing Open File Limit
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 You may wish to increase the open file limit as Rancher Desktop's default `ulimit` setting for pods may be too low, depending on your use case. This guide provides steps for increasing the open file limit using provisioning scripts alongside Rancher Desktop's internal processes.

--- a/versioned_docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
+++ b/versioned_docs/version-latest/how-to-guides/installing-uninstalling-extensions.md
@@ -2,10 +2,6 @@
 title: Installing and Uninstalling Rancher Desktop Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/installing-uninstalling-extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Extensions** feature introduced in the `v1.9.0-tech-preview` release enables you to use **Docker Desktop Extensions** within Rancher Desktop. The feature helps you extend Rancher Desktop's functionality to meet your additional needs. This guide will demonstrate how to install and uninstall Docker extensions in Rancher Desktop.

--- a/versioned_docs/version-latest/how-to-guides/migrating-images.md
+++ b/versioned_docs/version-latest/how-to-guides/migrating-images.md
@@ -2,10 +2,6 @@
 title: Migrating Moby Images Between Storage Drivers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/migrating-images"/>
-</head>
-
 Rancher Desktop stores images using two storage drivers when running the moby (docker) container engine: the **classic storage driver** and the **containerd snapshotter**. This page explains why images become hidden and how to access them.
 
 ## Background

--- a/versioned_docs/version-latest/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-latest/how-to-guides/mirror-private-registry.md
@@ -4,10 +4,6 @@ title: Mirroring Private Registries
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/mirror-private-registry"/>
-</head>
-
 Rancher Desktop can be configured to mirror private registries using either container runtime (`containerd` or `dockerd`) via provisioning scripts or updating the registry file used by `k3s`. Please see the `k3s` documentation for further information on [private registry configuration](https://docs.k3s.io/installation/private-registry).
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
+++ b/versioned_docs/version-latest/how-to-guides/provisioning-scripts.md
@@ -2,10 +2,6 @@
 title: Provisioning Scripts
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/provisioning-scripts"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Provisioning scripts can be used to override some of Rancher Desktop's internal processes. For example, scripts can be used to provide certain command line parameters to K3s, add additional mounts, increase ulimit value etc. This guide will explain how to set up your provisioning scripts for macOS, Linux, and Windows.

--- a/versioned_docs/version-latest/how-to-guides/rancher-on-rancher-desktop.md
+++ b/versioned_docs/version-latest/how-to-guides/rancher-on-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Rancher on Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/rancher-on-rancher-desktop"/>
-</head>
-
 While [Rancher](https://rancher.com/) and [Rancher Desktop](https://rancherdesktop.io/) share the _Rancher_ name, they do different things. Rancher Desktop is not Rancher on the Desktop. Rancher is a powerful solution to manage Kubernetes clusters. Rancher Desktop runs local Kubernetes and a container management platform. The two solutions complement each other. For example, you can install Rancher as a workload in Rancher Desktop.
 
 This guide outlines steps to install Rancher Dashboard on Rancher Desktop using `container runtime` or `helm` (local environment):

--- a/versioned_docs/version-latest/how-to-guides/running-air-gapped.md
+++ b/versioned_docs/version-latest/how-to-guides/running-air-gapped.md
@@ -2,10 +2,6 @@
 title: Running When Offline
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/running-air-gapped"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Rancher Desktop can be run when offline, aka in air-gapped mode. This document covers requirements

--- a/versioned_docs/version-latest/how-to-guides/setup-NGINX-Ingress-Controller.md
+++ b/versioned_docs/version-latest/how-to-guides/setup-NGINX-Ingress-Controller.md
@@ -2,10 +2,6 @@
 title: Setup NGINX Ingress Controller
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller"/>
-</head>
-
 Rancher Desktop uses K3s under the hood, which in turn uses Traefik as the default ingress controller for your Kubernetes cluster. However, there are unique use cases where NGINX may be required or preferred. Below steps show how to use NGINX Ingress controller for a sample deployment.
 
 ### Steps

--- a/versioned_docs/version-latest/how-to-guides/skaffold-and-rancher-desktop.md
+++ b/versioned_docs/version-latest/how-to-guides/skaffold-and-rancher-desktop.md
@@ -2,10 +2,6 @@
 title: Skaffold and Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/skaffold-and-rancher-desktop"/>
-</head>
-
 Skaffold is a command line tool that facilitates continuous development for Kubernetes-native applications. Skaffold handles the workflow for building, pushing, and deploying your application, and it provides building blocks for creating CI/CD pipelines. This enables you to focus on iterating on your application locally while Skaffold continuously deploys to your local or remote Kubernetes cluster. To learn more about Skaffold, refer to the project docs [here](https://skaffold.dev/docs/).
 
 In order to demonstrate the steps to set up Skaffold with Rancher Desktop, a sample nodejs app example is provided within the Rancher Desktop docs repository [here](https://github.com/rancher-sandbox/docs.rancherdesktop.io/tree/main/assets/express-sample). 

--- a/versioned_docs/version-latest/how-to-guides/traefik-ingress-example.md
+++ b/versioned_docs/version-latest/how-to-guides/traefik-ingress-example.md
@@ -4,10 +4,6 @@ title: Using the Traefik Ingress Controller
 
 import TabsConstants from '@site/core/TabsConstants';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/traefik-ingress-example"/>
-</head>
-
 Rancher Desktop uses `K3s` under the hood, which in turn uses [Traefik](https://doc.traefik.io/traefik/) as the [default Ingress controller](https://docs.k3s.io/networking#traefik-ingress-controller) for your Kubernetes cluster. As an example, the below steps outline creating simple services that can be routed by the Ingress object.
 
 ### Example Steps: Traefik Ingress Controller

--- a/versioned_docs/version-latest/how-to-guides/transfer-container-images.md
+++ b/versioned_docs/version-latest/how-to-guides/transfer-container-images.md
@@ -2,10 +2,6 @@
 title: Transfer Container Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/transfer-container-images"/>
-</head>
-
 Rancher Desktop provides `dockerd` and `containerd` as container engine options to manage containers. There are occasions when you might want to transfer the images from one container engine environment to the other. Or you may have migrated to Rancher Desktop from a different container management application and might want to bring the local images from the previous application environment to the Rancher Desktop environment.  This guide provides steps to transfer images using the `save` and `load` commands.
 
 ### Steps

--- a/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
+++ b/versioned_docs/version-latest/how-to-guides/using-testcontainers.md
@@ -2,10 +2,6 @@
 title: Using Testcontainers with Rancher Desktop
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/using-testcontainers"/>
-</head>
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/versioned_docs/version-latest/how-to-guides/vs-code-docker.md
+++ b/versioned_docs/version-latest/how-to-guides/vs-code-docker.md
@@ -2,10 +2,6 @@
 title: Debugging a Container App with VS Code Docker extension
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-docker"/>
-</head>
-
 The VS Code Docker extension makes it easy to build, manage, debug and deploy containerized applications in Visual Studio Code.
 
 ### Steps to debug a sample application running within a container

--- a/versioned_docs/version-latest/how-to-guides/vs-code-remote-containers.md
+++ b/versioned_docs/version-latest/how-to-guides/vs-code-remote-containers.md
@@ -2,10 +2,6 @@
 title: VS Code Remote Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/how-to-guides/vs-code-remote-containers"/>
-</head>
-
 The [Visual Studio Code Remote - Containers] extension lets you use a Docker container as a full-featured development environment, which helps ensure a consistent environment across developer machines and makes it easy for new team members and contributors to get up and running. Since Rancher Desktop supports Docker CLI via [Moby], you can use the Visual Studio Code Remote - Containers extension out-of-the-box.
 
 ### Steps to try a sample dev container

--- a/versioned_docs/version-latest/references/architecture.md
+++ b/versioned_docs/version-latest/references/architecture.md
@@ -2,10 +2,6 @@
 title: Architecture
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/architecture"/>
-</head>
-
 ![Rancher Desktop Architecture](../img/how-it-works-rancher-desktop.svg)
 
 Rancher Desktop is an electron-based application that wraps other tools while it also provides the user experience to create a simple experience. On macOS and Linux, Rancher Desktop leverages a virtual machine to run containerd or dockerd and Kubernetes. Windows Subsystem for Linux v2 is leveraged for Windows systems. All you need to do is download and run the application.

--- a/versioned_docs/version-latest/references/bundled-utilities.md
+++ b/versioned_docs/version-latest/references/bundled-utilities.md
@@ -6,10 +6,6 @@ import Version120 from '../bundled-utilities-version-info/v1.20.0.md';
 import Version121 from '../bundled-utilities-version-info/v1.21.0.md';
 import Version122 from '../bundled-utilities-version-info/v1.22.0.md';
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/bundled-utilities"/>
-</head>
-
 Rancher Desktop uses several utilities/subsystems as dependencies under the hood for various purposes. For example, **docker CLI** to interact with **dockerd**, **helm** to manage charts, **trivy** for container image scanning, etc. This page provides information about the versions of the bundled utilities that go into a specific Rancher Desktop release version.
 
 | Rancher Desktop Version | Dependency Versions |

--- a/versioned_docs/version-latest/references/rdctl-command-reference.md
+++ b/versioned_docs/version-latest/references/rdctl-command-reference.md
@@ -2,10 +2,6 @@
 title: "Command Reference: rdctl"
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/references/rdctl-command-reference"/>
-</head>
-
 `rdctl` is a command-line tool, included in Rancher Desktop that enables command-line access to GUI features. `rdctl` is developed to help users with tasks such as scripting (for automation, CI/CD), troubleshooting, remote management, etc. The current version of `rdctl` supports the below commands (with support for more commands to be added in upcoming releases):
 
 :::info

--- a/versioned_docs/version-latest/troubleshooting-tips.md
+++ b/versioned_docs/version-latest/troubleshooting-tips.md
@@ -2,10 +2,6 @@
 title: Troubleshooting Tips
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/troubleshooting-tips"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 This page provides tips to troubleshoot issues you may have with Rancher Desktop.

--- a/versioned_docs/version-latest/tutorials/using-persistent-storage.md
+++ b/versioned_docs/version-latest/tutorials/using-persistent-storage.md
@@ -2,10 +2,6 @@
 title: Using Persistent Storage
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/using-persistent-storage/"/>
-</head>
-
 Containers are, by design, ephemeral and stateless. However, most real-world use cases require containers to produce or consume data that often needs to be persisted. To address this challenge, container engines offer mechanisms such as **Bind mounts** and **Volumes**. Both the docker and nerdctl CLIs provide options `-v` and `--mount` to start a container with a bind mount or a volume.
 
 ## Bind mount

--- a/versioned_docs/version-latest/tutorials/working-with-containers.md
+++ b/versioned_docs/version-latest/tutorials/working-with-containers.md
@@ -2,10 +2,6 @@
 title: Working with Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-containers"/>
-</head>
-
 `nerdctl` is a Docker-compatible CLI for containerd. The primary goal of `nerdctl` is to facilitate experimenting with cutting-edge features of containerd that are not present in Docker.
 
 [Moby](https://github.com/moby/moby) is an open-source project that was created by Docker to enable and accelerate software containerization. Components include container build tools, a container registry, orchestration tools, and a runtime, and more. The Docker CLI uses the Moby runtime. 

--- a/versioned_docs/version-latest/tutorials/working-with-images.md
+++ b/versioned_docs/version-latest/tutorials/working-with-images.md
@@ -2,10 +2,6 @@
 title: Working with Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-images"/>
-</head>
-
 Rancher Desktop provides the ability to build, push, and pull images via the
 [NERDCTL](https://github.com/containerd/nerdctl) project and the Docker CLI.
 

--- a/versioned_docs/version-latest/tutorials/working-with-webassembly.md
+++ b/versioned_docs/version-latest/tutorials/working-with-webassembly.md
@@ -2,10 +2,6 @@
 title: Working with WebAssembly
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/tutorials/working-with-webassembly"/>
-</head>
-
 Rancher Desktop 1.13.0 added experimental support for running WebAssembly (Wasm) applications. This feature needs to be enabled in  [Preferences > Container Engine > General](../ui/preferences/container-engine/general.md).
 
 :::caution warning

--- a/versioned_docs/version-latest/ui/containers.md
+++ b/versioned_docs/version-latest/ui/containers.md
@@ -3,10 +3,6 @@ sidebar_label: Containers
 title: Containers
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/containers"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-latest/ui/diagnostics.md
+++ b/versioned_docs/version-latest/ui/diagnostics.md
@@ -3,10 +3,6 @@ sidebar_label: Diagnostics
 title: Diagnostics
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/diagnostics"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **Diagnostics** feature runs several checks in the background to detect common problems such as missing minimum requirements, misconfigurations, etc., in your environment to help you self-troubleshoot and fix Rancher Desktop application issues.

--- a/versioned_docs/version-latest/ui/extensions.md
+++ b/versioned_docs/version-latest/ui/extensions.md
@@ -3,10 +3,6 @@ sidebar_label: Extensions
 title: Extensions
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/extensions"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ### Catalog

--- a/versioned_docs/version-latest/ui/general.md
+++ b/versioned_docs/version-latest/ui/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The **General** tab provides information on communication channels where users can connect with the Rancher Desktop team and community to ask questions, report bugs, or discuss Rancher Desktop in general.

--- a/versioned_docs/version-latest/ui/images.md
+++ b/versioned_docs/version-latest/ui/images.md
@@ -3,10 +3,6 @@ sidebar_label: Images
 title: Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-latest/ui/port-forwarding.md
+++ b/versioned_docs/version-latest/ui/port-forwarding.md
@@ -3,10 +3,6 @@ sidebar_label: Port Forwarding
 title: Port Forwarding
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/port-forwarding"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-latest/ui/preferences/application/behavior.md
+++ b/versioned_docs/version-latest/ui/preferences/application/behavior.md
@@ -3,10 +3,6 @@ sidebar_label: Behavior
 title: Behavior
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/behavior"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of application behavior upon startup, background process behavior, and notification icon display.

--- a/versioned_docs/version-latest/ui/preferences/application/environment.md
+++ b/versioned_docs/version-latest/ui/preferences/application/environment.md
@@ -3,10 +3,6 @@ sidebar_label: Environment
 title: Environment
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/environment"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for configuration of the `$PATH` variable in the users shell in order to interact with Rancher Desktop installed utilities.

--- a/versioned_docs/version-latest/ui/preferences/application/general.md
+++ b/versioned_docs/version-latest/ui/preferences/application/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/application/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Allows for enablement of automatic updates, as well as an optional field to allow Rancher Desktop to collect anonymous statistics to help improve the application.

--- a/versioned_docs/version-latest/ui/preferences/container-engine/allowed-images.md
+++ b/versioned_docs/version-latest/ui/preferences/container-engine/allowed-images.md
@@ -3,10 +3,6 @@ sidebar_label: Allowed Images
 title: Allowed Images
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/allowed-images"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 The `Allowed Images` tab lets you control which registry artifacts you can access within Rancher Desktop. For example, you may want to pull container images only from your organization's private registry or only from your department-specific namespace in your organization's registry, etc. You can specify image name patterns to allow accessing images only from specific registries and/or repositories.

--- a/versioned_docs/version-latest/ui/preferences/container-engine/general.md
+++ b/versioned_docs/version-latest/ui/preferences/container-engine/general.md
@@ -3,10 +3,6 @@ sidebar_label: General
 title: General
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/container-engine/general"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 Set the [container runtime] for Rancher Desktop. Users have the option of [containerd] which provides namespaces for containers and the use of nerdctl or [dockerd (moby)] which enables the Docker API and the use of the Docker CLI. Only one container runtime will function at a time.

--- a/versioned_docs/version-latest/ui/preferences/kubernetes.md
+++ b/versioned_docs/version-latest/ui/preferences/kubernetes.md
@@ -3,10 +3,6 @@ sidebar_label: Kubernetes
 title: Kubernetes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/kubernetes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/emulation.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/emulation.md
@@ -3,10 +3,6 @@ sidebar_label: Emulation
 title: Emulation (macOS)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/emulation"/>
-</head>
-
 ### VZ
 
  ![](rd-versioned-asset://preferences/macOS_virtualMachine_tabEmulation_vz.png)

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/hardware.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/hardware.md
@@ -3,10 +3,6 @@ sidebar_label: Hardware
 title: Hardware (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/hardware"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os">

--- a/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
+++ b/versioned_docs/version-latest/ui/preferences/virtual-machine/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes (macOS & Linux)
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/virtual-machine/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 ## Mount Type

--- a/versioned_docs/version-latest/ui/preferences/wsl/integrations.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/integrations.md
@@ -3,10 +3,6 @@ sidebar_label: Integrations
 title: Integrations
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/integrations"/>
-</head>
-
 The Integrations tab allows for the option to make the Rancher Desktop Kubernetes configuration accessible to any Linux distributions configured for WSL. Once enabled, you can communicate with the Rancher Desktop Kubernetes cluster using tools like `kubectl` from within the WSL distribution.
 
 ![](rd-versioned-asset://preferences/Windows_wsl_tabIntegrations.png)

--- a/versioned_docs/version-latest/ui/preferences/wsl/proxy.md
+++ b/versioned_docs/version-latest/ui/preferences/wsl/proxy.md
@@ -3,10 +3,6 @@ sidebar_label: Proxy
 title: Proxy
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/preferences/wsl/proxy"/>
-</head>
-
 ![](rd-versioned-asset://preferences/Windows_wsl_tabProxy.png)
 
 ### WSL Proxy

--- a/versioned_docs/version-latest/ui/snapshots.md
+++ b/versioned_docs/version-latest/ui/snapshots.md
@@ -3,10 +3,6 @@ sidebar_label: Snapshots
 title: Snapshots
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/snapshots"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-latest/ui/troubleshooting.md
+++ b/versioned_docs/version-latest/ui/troubleshooting.md
@@ -3,10 +3,6 @@ sidebar_label: Troubleshooting
 title: Troubleshooting
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/troubleshooting"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>

--- a/versioned_docs/version-latest/ui/volumes.md
+++ b/versioned_docs/version-latest/ui/volumes.md
@@ -3,10 +3,6 @@ sidebar_label: Volumes
 title: Volumes
 ---
 
-<head>
-  <link rel="canonical" href="https://docs.rancherdesktop.io/ui/volumes"/>
-</head>
-
 import TabsConstants from '@site/core/TabsConstants';
 
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>


### PR DESCRIPTION
Fixes #432.

## Problem

Every page's canonical link pointed at a redirect, and on older versions at the wrong page.

- Docusaurus derives canonical and `og:url` from each page's permalink, but with no `trailingSlash` set those URLs dropped the trailing slash that GitHub Pages 301-redirects to.
- The 800 hand-written `<link rel="canonical">` tags pointed every version at the latest URL (good intent), but also lacked trailing slashes, and they never corrected `og:url`.

## Change

Generate the canonicals instead of hand-maintaining 800 of them:

- `trailingSlash: true` aligns Docusaurus output with how GitHub Pages serves, fixing the slash on canonical, `og:url`, the sitemap, and internal links.
- A swizzled `DocItem/Metadata` points each page's canonical and `og:url` at the latest version of the same doc, falling back to the page's own URL when the doc no longer exists in latest.
- Removes all 810 `<head>` blocks (the 800 canonical tags plus 10 empty leftovers).
- Drops the `docs.rancherdesktop.io` lychee exclusion from #524. It existed only to stop a new page's markdown canonical from 404ing before deploy, and canonicals no longer live in the markdown the checker scans.

## Verification

Built the site and inspected the static HTML across all 1017 pages:

- Zero canonicals or `og:url` without a trailing slash; zero pages with a duplicate canonical.
- `/1.7/faq/`, `/1.22/faq/`, and `/next/faq/` all canonical to `…/faq/`; roots canonical to `…/`.
- A page removed in latest (`1.10/ui/preferences/wsl/network/`) self-canonicals to its own URL.
- `yarn build` passes — `onBrokenLinks: 'throw'` did not fire, so trailing slashes broke no internal links.

Pre-existing broken-anchor warnings (`#macOS--Linux`, `#Windows` in `provisioning-scripts`) are unrelated and left as-is.