### PR TITLE
Update rdctl reference for 1.23.0

### DIFF
--- a/docs/references/rdctl-command-reference.md
+++ b/docs/references/rdctl-command-reference.md
@@ -334,7 +334,7 @@ Global Flags:
 ```console autoupdate=true
 $ rdctl list-settings
 {
-  "version": 17,
+  "version": 18,
   "application": {
     "adminAccess": false,
     "debug": false,
@@ -357,7 +357,8 @@ $ rdctl list-settings
     "hideNotificationIcon": false,
     "window": {
       "quitOnClose": false
-    }
+    },
+    "theme": "system"
   },
   "containerEngine": {
     "allowedImages": {
@@ -380,7 +381,7 @@ $ rdctl list-settings
     "integrations": {}
   },
   "kubernetes": {
-    "version": "1.34.3",
+    "version": "1.35.5",
     "port": 6443,
     "enabled": true,
     "options": {
@@ -617,6 +618,7 @@ Flags:
       --application.path-management-strategy string                     update PATH to include ~/.rd/bin (allowed values: [manual, rcfiles])
       --application.start-in-background                                 start app without window
       --application.telemetry.enabled                                   allow collection of anonymous statistics
+      --application.theme string                                        set the color theme (system follows OS setting) (allowed values: [system, light, dark])
       --application.updater.enabled                                     automatically update to the latest release
       --application.window.quit-on-close                                terminate app when the main window is closed
       --container-engine.allowed-images.enabled                         only allow images to be pulled that match the allowed patterns
@@ -695,7 +697,7 @@ Run `rdctl version` to see the current rdctl CLI version.
 
 ```console autoupdate=true
 $ rdctl version
-rdctl client version: v1.22.0, targeting server version: v1
+rdctl client version: v1.23.0, targeting server version: v1
 ```
 
 </details>

--- a/scripts/update-rdctl-reference
+++ b/scripts/update-rdctl-reference
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Regenerate the rdctl command reference from the rdctl on PATH, then
+# normalize machine-specific output:
+#   - collapse the personalized config-path default to .../rancher-desktop/rd-engine.json
+#   - rewrite the reported version to the release version you pass in
+#
+# Rancher Desktop must be running, because several blocks query the live backend.
+#
+# Usage: scripts/update-rdctl-reference <release-version>
+#
+# Pass the release version as an argument (e.g. 1.23.0). RC and dev builds report
+# a git-describe version off the previous release tag (e.g. v1.22.3-1194-g066ecbf92),
+# which is why the script requires it.
+#
+# Known issues, to revisit for the 1.24.0 release:
+#   - list-settings reports this machine's effective settings, so after running you
+#     must hand-edit host-specific values (memoryInGB, application.updater.enabled,
+#     ...) back to the documented defaults.
+#   - The snapshot block runs create/delete/list --json; its output depends on local
+#     snapshots and carries a live timestamp, so review it by hand. Better: give it
+#     the "..." skip-output attribute, or generate fixed example output.
+#   - snapshot create can fail on a freshly initialized VM (missing basedisk).
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: scripts/update-rdctl-reference <release-version>"
+    echo
+    echo "Regenerate the rdctl command reference and normalize machine-specific"
+    echo "output. Pass the release version (e.g. 1.23.0); Rancher Desktop must be running."
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+esac
+
+if [ "$#" -lt 1 ]; then
+    echo "error: release version required (e.g. scripts/update-rdctl-reference 1.23.0)" >&2
+    echo >&2
+    usage >&2
+    exit 1
+fi
+
+release=$1
+case "$release" in
+    v*) ;;
+    *) release=v$release ;;
+esac
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "$script_dir/.." && pwd)
+reference=$repo_root/docs/references/rdctl-command-reference.md
+codeblocks=$script_dir/update-codeblocks
+
+if ! command -v rdctl >/dev/null 2>&1; then
+    echo "error: rdctl not found on PATH" >&2
+    exit 1
+fi
+
+if ! rdctl list-settings >/dev/null 2>&1; then
+    echo "error: 'rdctl list-settings' failed; is Rancher Desktop running?" >&2
+    exit 1
+fi
+
+installed=$(rdctl version | perl -ne 'print $1 if /rdctl client version: (v\S+?),/')
+echo "Installed rdctl build: ${installed:-unknown}"
+echo "Writing release version: $release"
+
+"$codeblocks" --update "$reference"
+
+RELEASE_VERSION=$release perl -i -pe '
+    s{\(default \K.*?(?=/rancher-desktop/rd-engine\.json)}{...}g;
+    s{(rdctl client version: )\S+(?=, targeting)}{$1$ENV{RELEASE_VERSION}};
+' "$reference"
+
+echo
+git -C "$repo_root" diff --stat -- "$reference" 2>/dev/null || true
+echo
+echo "Review the diff: the 'rdctl snapshot list' block reflects local snapshots and includes timestamps."


### PR DESCRIPTION
Regenerate `docs/references/rdctl-command-reference.md` for 1.23.0, and add the script that produces it.

`scripts/update-rdctl-reference <version>` runs `update-codeblocks` on the reference, then normalizes the machine-specific output: it collapses the personalized `rd-engine.json` config-path and rewrites the reported `rdctl` version to the release version. The version is an explicit argument because RC and dev builds report a git-describe version off the previous release tag.

Reference changes for 1.23.0: settings schema 17 → 18, a new `application.theme` setting and flag, and Kubernetes 1.34.3 → 1.35.5.