### PR TITLE
Fix typecheck failures and run typecheck in CI

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -54,5 +54,7 @@ jobs:
           exit 1
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Typecheck
+        run: yarn typecheck
       - name: Test build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.1",
-    "@tsconfig/docusaurus": "^1.0.4",
-    "typescript": "^4.5.2"
+    "@tsconfig/docusaurus": "^2.0.9",
+    "typescript": "^5.9.3"
   },
   "browserslist": {
     "production": [

--- a/src/components/HomepageFeatures.tsx
+++ b/src/components/HomepageFeatures.tsx
@@ -5,7 +5,7 @@ import styles from './HomepageFeatures.module.css';
 type FeatureItem = {
   title: string;
   image: string;
-  description: JSX.Element;
+  description: React.JSX.Element;
 };
 
 const FeatureList: FeatureItem[] = [
@@ -55,7 +55,7 @@ function Feature({title, image, description}: FeatureItem) {
   );
 }
 
-export default function HomepageFeatures(): JSX.Element {
+export default function HomepageFeatures(): React.JSX.Element {
   return (
     <section className={styles.features}>
       <div className="container">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
-  "compilerOptions": {
-    "baseUrl": "."
-  }
+  "extends": "@tsconfig/docusaurus/tsconfig.json"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,10 +2568,10 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@tsconfig/docusaurus@^1.0.4":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-1.0.7.tgz#a3ee3c8109b3fec091e3d61a61834e563aeee3c3"
-  integrity sha512-ffTXxGIP/IRMCjuzHd6M4/HdIrw1bMfC7Bv8hMkTadnePkpe0lG0oDSdbRpSDZb2rQMAgpbWiR10BvxvNYwYrg==
+"@tsconfig/docusaurus@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-2.0.9.tgz#e530ae78bca4f88917af48fe25a944d6d6bdcdf5"
+  integrity sha512-0jVxZCgy2v7TnJrW9kVNikNwJHeiWb68Zhiiw2vHw4tzBFSP5vS2zn3O5EY2oPEVz5dXZRkK7MnWG3Ay5q0mIg==
 
 "@types/body-parser@*":
   version "1.19.5"
@@ -9071,10 +9071,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.5.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 undici-types@~6.21.0:
   version "6.21.0"


### PR DESCRIPTION
**Fix typecheck** — typecheck failed on `main` for two reasons: `@types/react@19` moved the global `JSX` namespace under `React`, and the TypeScript 4.x / `@tsconfig/docusaurus@1` toolchain couldn't import Docusaurus's ESM-only remark dependencies. Bumps TypeScript to 5.9 and `@tsconfig/docusaurus` to 2 (`moduleResolution: bundler`), and references the namespace as `React.JSX.Element`.

**Run typecheck in CI** — nothing ran `tsc`, so it broke unnoticed. Adds a typecheck step to the PR workflow.

**Verification** — `yarn typecheck` and `yarn build` both pass; lockfile churn is 16 lines.
