### PR TITLE
Fix broken anchors in versioned mirror-private-registry docs

### DIFF
--- a/versioned_docs/version-1.14/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.14/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.15/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.15/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.16/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.16/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.17/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.17/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.18/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.18/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.19/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.19/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.20/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.20/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.21/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.21/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-1.22/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-1.22/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 

--- a/versioned_docs/version-latest/how-to-guides/mirror-private-registry.md
+++ b/versioned_docs/version-latest/how-to-guides/mirror-private-registry.md
@@ -9,7 +9,7 @@ Rancher Desktop can be configured to mirror private registries using either cont
 <Tabs groupId="os" defaultValue={TabsConstants.defaultOs}>
 <TabItem value="Linux">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -41,7 +41,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="macOS">
 
-Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macOS--Linux) that can be used to mirror private registries.
+Below is an example [provisioning script](../how-to-guides/provisioning-scripts.md#macos--linux) that can be used to mirror private registries.
 
 Check if you have the `override.yaml` file in the path below, otherwise you can create the file in the path with the suggested provisioning commands.
 
@@ -74,7 +74,7 @@ rdctl shell -- cat /etc/rancher/k3s/registries.yaml
 </TabItem>
 <TabItem value="Windows">
 
-Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#Windows) can be utilized to mirror private registries using a `.start` file.
+Ensure that you have initialized the application with a first run in order to create the `\provisioning\` directory. Once created, [provisioning scripts](../how-to-guides/provisioning-scripts.md#windows) can be utilized to mirror private registries using a `.start` file.
 
 The file path and example provisioning script are provided below. After you have created the file with the appropriate configuration, restart the Rancher Desktop application for the provisioning script to take effect.
 


### PR DESCRIPTION
The "mirror a private registry" pages linked to `provisioning-scripts#macOS--Linux` and `#Windows`, but Docusaurus lowercases heading IDs (`#macos--linux`, `#windows`). The mixed-case links resolved to nothing, dropping readers at the top of the page instead of the right section.