### PR TITLE
Tighten the tone in the launch blog posts

### DIFF
--- a/blog/2026-06-17-history-of-rancher-desktop.md
+++ b/blog/2026-06-17-history-of-rancher-desktop.md
@@ -7,7 +7,7 @@ discussion: https://github.com/rancher-sandbox/rancher-desktop-2/discussions/471
 
 In October 2020, Rancher Desktop was a tray icon and a single shell command.
 Click the icon, and it ran `minikube start` to bring up a Kubernetes cluster on
-your Mac. That was the whole thing: nine files, one good idea, and a note in the
+your Mac. The whole thing was nine files, one good idea, and a note in the
 source that read, more or less, *this is just a quick proof of concept*.
 
 <!-- truncate -->
@@ -104,28 +104,27 @@ through the app.
 ## What people actually wanted
 
 The request for Linux support surprised us. On Linux you can already run k3s,
-containerd, and Docker natively. What does a desktop app add? Not the
-containers. The value was being able to throw the whole thing away. A factory
-reset wipes the VM back to nothing, worth a lot when your environment drifts
-into a state you no longer understand. People didn't want another way to
-run containers. They wanted an undo button for their development machine (and
-later, snapshots).
+containerd, and Docker natively, so a desktop app doesn't add the containers.
+Its value was being able to throw the whole thing away. A factory reset wipes
+the VM back to nothing, worth a lot when your environment drifts into a state
+you no longer understand. People wanted an undo button for their development
+machine (and later, snapshots).
 
 ## A backend trapped in the app
 
-Two things made Rancher Desktop easier to work with, and both ran into the same
-wall.
+Two features we built to make Rancher Desktop easier to work with ran into the
+same limit.
 
-The first was rdctl, a command-line tool for driving Rancher Desktop without
+rdctl was a command-line tool for driving Rancher Desktop without
 touching the GUI. It let us write our integration tests as plain shell scripts
 instead of clicking through the interface, and it let users automate their
 setup. But not everything was reachable from it. Port forwarding, for one, still
 went through private messaging between the GUI and the backend, never exposed
 through the REST API, so the GUI could do things no script could.
 
-The second was snapshots, saving the VM's state to restore later. A simple
-feature, an awkward implementation, because the backend has to stop while its
-disk is copied, and the backend lives inside the GUI. So taking a snapshot
+Snapshots hit it too. Saving the VM's state to restore later was a simple
+feature with an awkward implementation, because the backend has to stop while
+its disk is copied, and the backend lives inside the GUI. So taking a snapshot
 turned into a small contortion. The GUI launches rdctl, which calls back into
 the GUI to ask it to shut its own backend down, takes the snapshot, then asks it
 to start back up. Cancelling was worse. There was no clean channel for it, so
@@ -140,11 +139,11 @@ to an AI agent to drive, that's real friction.
 ## What five years taught us
 
 Step back, and a pattern runs through all of it. Every feature got a little more
-difficult to implement than the last. Two backends to change in lockstep. An
-engine welded to its own UI. A guest OS that couldn't reach the GPU. None of it
-was a mistake exactly (each call was reasonable when we made it), but the costs
-compounded, until we were spending more time maintaining the existing machinery
-than building anything new.
+difficult to implement than the last. We had two backends to change in lockstep,
+an engine welded to its own UI, and a guest OS that couldn't reach the GPU. None
+of it was a mistake exactly (each call was reasonable when we made it), but the
+costs compounded, until we were spending more time maintaining the existing
+machinery than building anything new.
 
 The parts that aged well point the way. Building on Lima gave us one backend for
 macOS and Linux and an upstream community to share the load. And the
@@ -152,12 +151,12 @@ command-line tool we'd built for our own tests turned out to matter more than we
 planned. A tool an AI model can explore and drive on its own is also exactly
 what you want now that so much work is handed to agents.
 
-So Rancher Desktop 2.0 starts over, on purpose. One backend across every
-platform, Windows included. The backend lifted out of the UI into something you
-can run on its own: headless, scripted, snapshotted by itself. A guest that can
-talk to your GPU. Not because the first five years were wrong, but because they
-taught us exactly what the foundation needed to be. The rest of this blog is
-about what we're building on it.
+So Rancher Desktop 2.0 starts over, on purpose. It runs one backend across every
+platform (including Windows). The backend lives outside the UI now, so you can
+run it on its own: headless, scripted, snapshotted by itself. And the guest can
+talk to your GPU. The first five years weren't wrong; they taught us exactly
+what the foundation needed to be. The rest of this blog is about what we're
+building on it.
 
 [^k3s]: k3s is Rancher's lightweight Kubernetes distribution, small enough to run on a laptop or edge device.
 

--- a/blog/2026-06-18-installing-rancher-desktop-2.md
+++ b/blog/2026-06-18-installing-rancher-desktop-2.md
@@ -14,8 +14,8 @@ couple of commands away from a working container engine.
 
 2.0 installs beside Rancher Desktop 1.x without touching it, with a
 separate package and separate data. Install or remove them in any order. On
-Linux, the RPM and DEB packages are the one exception in this alpha and will
-not install alongside Rancher Desktop 1.x. (The
+Linux, the RPM and DEB packages are the one exception in this alpha and won't
+install alongside Rancher Desktop 1.x. (The
 [welcome post](/blog/welcome-to-rancher-desktop-2) covers what 2.0 is and how
 it differs; this one is about getting it running.)
 
@@ -33,7 +33,7 @@ build on an Intel Mac. Open it, drag the app into Applications, and launch it
 from there.
 
 On Windows, download the installer, `Rancher.Desktop.Setup.2.0.0-alpha.1.msi`,
-and run it. Install WSL2 first if you have not already; 2.0 runs its Linux VM
+and run it. Install WSL2 first if you haven't already; 2.0 runs its Linux VM
 through WSL2, just as Rancher Desktop 1.x does.
 
 On Linux, install from our RPM or DEB repositories[^linux], or run the AppImage,
@@ -44,7 +44,7 @@ VM image, which can take a while on a slow connection. After that the app is
 talking to a running container engine, and you can manage containers, images,
 and volumes from its window.
 
-One thing the app will not do for you yet: turn on Kubernetes. It starts with
+One thing the app won't do for you yet: turn on Kubernetes. It starts with
 Kubernetes off, and this alpha has no settings screen or first-run dialog to
 change that, so you enable it from the command line. The first run installs
 `rdd` into `~/.rd2/bin`; put that on your `PATH` (or call `~/.rd2/bin/rdd`
@@ -61,8 +61,8 @@ is the only switch.
 ## Or just the daemon
 
 If you want a container engine and a cluster with no window on screen, skip the
-app and download the single `rdd` binary instead. It is the whole backend in
-one file; there is no installer and nothing to unpack.
+app and download the single `rdd` binary instead. It's the whole backend in
+one file; there's no installer and nothing to unpack.
 
 The binaries are in the same GitHub release. The name is `rdd-` followed by the
 version, the operating system, and the CPU architecture: on an Apple silicon
@@ -82,13 +82,13 @@ From there, one command gets you a running container:
 rdd run docker run --rm hello-world
 ```
 
-`rdd run` is the no-commitment way to use 2.0. It starts the daemon if it is
+`rdd run` is the no-commitment way to use 2.0. It starts the daemon if it's
 not already up, then runs your command with the `PATH` and the Docker and
 Kubernetes contexts pointed at 2.0 for that command only. It leaves your own
 configuration untouched. So if your machine is already set up for Rancher
 Desktop 1.x, leave it that way and reach for 2.0 with `rdd run` when you want
 to try something. The very first start downloads the openSUSE Leap image and
-brings the VM up, which can take a while on a slow connection; after that it is
+brings the VM up, which can take a while on a slow connection; after that it's
 quick.
 
 Kubernetes works the same way. On a fresh setup, `rdd run kubectl get node`
@@ -125,13 +125,13 @@ export PATH="$HOME/.rd2/bin:$PATH"
 ```
 
 What you find there depends on how you installed. `rdd` provides `kubectl`
-itself, so it is there either way. `docker` and `helm` come with the full app,
+itself, so it's there either way. `docker` and `helm` come with the full app,
 which links them into `~/.rd2/bin` alongside its other bundled tools and the
 credential helpers; with the daemon-only download, supply `docker` and `helm`
 yourself.
 
 Both the Docker and Kubernetes contexts are
-named `rancher-desktop-2`, and 2.0 will not take over a context you already
+named `rancher-desktop-2`, and 2.0 won't take over a context you already
 have selected. If you run both side by side, move between them by switching
 contexts:
 
@@ -148,19 +148,19 @@ rdd start   # bring the backend up
 rdd stop    # take it down, keep your data
 ```
 
-There is no upgrade path between previews yet, so each new alpha starts from a
+There's no upgrade path between previews yet, so each new alpha starts from a
 clean slate. `rdd svc delete` stops the daemon and removes everything 2.0
 created (the VM, the cluster, your settings, and the daemon's own data),
-keeping only the download cache so a reinstall does not refetch the VM image.
-It is also how you uninstall; after it runs, just delete the `rdd` binary or
+keeping only the download cache so a reinstall doesn't refetch the VM image.
+It's also how you uninstall; after it runs, just delete the `rdd` binary or
 remove the app. The cache it leaves behind is Lima's, not ours
 (`~/Library/Caches/lima` on macOS, `~/.cache/lima` on Linux,
 `~/AppData/Local/lima` on Windows); delete it too if you want to reclaim all
 the space. A later release will handle that for you, clearing distro images
 from earlier previews automatically and adding a command to empty the cache.
 
-That is the alpha: install it one of two ways, start it, and run a container.
-It may break on setups we have never seen, and if it does, please tell us.
+That's the alpha: install it one of two ways, start it, and run a container.
+It may break on setups we've never seen, and if it does, please tell us.
 
 ## A glimpse underneath
 
@@ -230,10 +230,10 @@ metadata:
   resourceVersion: ""
 ```
 
-This is not the cluster you turned on earlier; it is Rancher Desktop
+This is not the cluster you turned on earlier; it's Rancher Desktop
 representing itself through the same API your tools already speak. That means
 anything that drives Kubernetes can also drive Rancher Desktop, without a
-bespoke SDK or a private protocol. There is a lot to say about that, and it
+bespoke SDK or a private protocol. There's a lot to say about that, and it
 gets a post of its own.
 
 ## The commands in one place

--- a/blog/2026-06-19-welcome-to-rancher-desktop-2.md
+++ b/blog/2026-06-19-welcome-to-rancher-desktop-2.md
@@ -6,13 +6,13 @@ discussion: https://github.com/rancher-sandbox/rancher-desktop-2/discussions/473
 ---
 
 Rancher Desktop 2.0 is a full rewrite, and the first build is ready for you
-to try. There is an alpha you can download today and run on your own machine.
+to try. There's an alpha you can download today and run on your own machine.
 
 <!-- truncate -->
 
-Let's call it what it is: an early tech preview. It is rough, and not meant for
+Let's call it what it is: an early tech preview. It's rough, and not meant for
 production. It exists so you can see that 2.0 is real and already running, and
-so you can tell us what you would like while the architecture is still soft
+so you can tell us what you'd like while the architecture is still soft
 enough to change.
 
 ## What 2.0 is
@@ -24,18 +24,18 @@ one backend instead of two, the engine lifted out of the GUI, and a different
 guest OS underneath. 2.0 is that idea, built from scratch.
 
 At the center is a new background program called `rdd`, the Rancher Desktop
-Daemon, and it is the part that does the real work. It runs the virtual machine
+Daemon, and it's the part that does the real work. It runs the virtual machine
 (using Lima on all platforms now, including Windows), it starts your container
 engine, and it manages your Kubernetes cluster. `rdd` exposes all of this
 through an API, but not a custom one; it actually speaks the Kubernetes API, so
 you can talk to it directly with `kubectl` or any of the standard client
-libraries, and there is no new SDK to learn. The desktop app is really just
+libraries, and there's no new SDK to learn. The desktop app is really just
 another client without any special privileges; it talks to `rdd` the same way
 any other tool would.
 
 Because the work lives in `rdd` instead of inside a window, you can run the
 whole thing without ever opening the GUI. And `rdd` is one self-contained
-executable; there is no installer and no separate daemon and command-line tool,
+executable; there's no installer and no separate daemon and command-line tool,
 just one file that is both the backend and the way you drive it. Download it,
 start it from the command line, and you have a container engine and a cluster:
 on a headless server, on a CI runner, or in your own terminal. Deploying it
@@ -43,23 +43,23 @@ just means copying one file. Rancher Desktop never had a way to do this,
 because the engine lived inside the app, and the app had to be on screen.
 
 The guest VM runs openSUSE Leap now instead of Alpine, and the reason is glibc;
-much of the GPU and AI tooling people ask for needs it, and Alpine's musl does
-not provide it. GPU support is not built yet, but the guest OS no longer rules
-it out.
+much of the GPU and AI tooling people ask for needs it, and Alpine's musl
+doesn't provide it. GPU support isn't built yet, but the guest OS no longer
+rules it out.
 
 ## Why an alpha, and why now
 
-We could have kept this private until it looked polished, but we would rather
+We could have kept this private until it looked polished, but we'd rather
 not. Putting it out now, rough edges and all, does two things for us.
 
-It shows that "we will do that in 2.0" means a workstream already running, not a
+It shows that "we'll do that in 2.0" means a workstream already running, not a
 promise about some distant year. And it puts the design in front of you early,
 when your feedback still counts. If your setup depends on something specific,
 this is the moment to say so, before we lock in decisions.
 
 ## What you can do today
 
-This is a working preview, not a finished product. Here is what runs right now:
+This is a working preview, not a finished product. Here's what runs right now:
 
 - Start, stop, and delete Rancher Desktop 2.0, from the GUI or the command line.
 - Install and run it with no GUI at all: the daemon with your local
@@ -71,20 +71,20 @@ This is a working preview, not a finished product. Here is what runs right now:
 
 ## What is not there yet
 
-So you are not caught off guard:
+So you're not caught off guard:
 
 - moby is the only container engine for now.
-- There is no settings screen. You pick your Kubernetes version from the command
+- There's no settings screen. You pick your Kubernetes version from the command
   line.
 - So far, the interface covers containers, images, and volumes, plus the
   cluster dashboard.
-- There is no upgrade path between previews. Each new build means a clean slate:
+- There's no upgrade path between previews. Each new build means a clean slate:
   factory reset, then install fresh. It stays that way until 2.0 reaches a real
   release.
 
 ## It can be installed beside Rancher Desktop 1.x
 
-You do not have to choose. 2.0 installs next to Rancher Desktop 1.x, and the
+You don't have to choose. 2.0 installs next to Rancher Desktop 1.x, and the
 two ignore each other, with a separate package and separate data. Install or
 remove them in either order. The Linux RPM and DEB packages are the exception
 in this alpha.[^linux] Don't run them both at once, though; there are likely to
@@ -95,23 +95,23 @@ be port and socket conflicts.
 The full app, GUI plus bundled tools, comes from the [latest
 release](https://github.com/rancher-sandbox/rancher-desktop-2/releases/latest)
 on GitHub for Windows and macOS (Intel and Apple silicon), and from our RPM and
-DEB repositories and AppImages on Linux, the same places you would reach for
+DEB repositories and AppImages on Linux, the same places you'd reach for
 Rancher Desktop 1.x. If all you want is the daemon, download the single `rdd`
-binary for your platform and you are two commands away from a running
+binary for your platform and you're two commands away from a running
 container.
 
 A real [installation and usage
 walkthrough](/blog/installing-rancher-desktop-2) is a separate post in this
 series.
 
-This is alpha software. Things will break, especially in corners we have never
+This is alpha software. Things will break, especially in corners we've never
 tested on a machine configured like yours. When they do, please tell us; that
-feedback is a big part of why we are shipping this early.
+feedback is a big part of why we're shipping this early.
 
 ## Staying in the loop
 
 There are no docs for 2.0 yet, so for now this blog takes their place. As the
-work moves, we will write about how the pieces fit and what becomes newly
+work moves, we'll write about how the pieces fit and what becomes newly
 possible: the daemon and its API, networking, snapshots, the AI story, whatever
 we just released. To find out when the next preview drops, subscribe to the
 feed.


### PR DESCRIPTION
A follow-up to #540. The welcome and install posts still read a bit formal, so this relaxes the phrasing, and the history post had a few clunky spots to smooth out.