### PR TITLE
Add a how-to for running development builds

### DIFF
--- a/blog/2026-07-16-installing-development-builds.md
+++ b/blog/2026-07-16-installing-development-builds.md
@@ -36,8 +36,8 @@ outside the VM. Back up anything you can't afford to lose before you start.
 
 So this is really for people who are comfortable switching between versions and
 running factory resets, and who can put things back when a build breaks
-something. If that's not you, it's fine to wait for the release; the fix will
-land there soon enough.
+something. If that's not you, I'd wait for the release; the fix will land there
+soon enough.
 
 ## The short version
 
@@ -91,7 +91,7 @@ Development builds come from GitHub Actions[^actions], from the workflow named
 For the latest `main`, open the **Actions** tab, then filter to the **Package**
 workflow and the `main` branch. Or skip both dropdowns and type
 `branch:main workflow:Package` into the search box. Now pick the newest run with
-a green checkmark, which means the whole run passed, so its builds are complete.
+a green checkmark, which means the whole run passed and its builds are complete.
 
 <img
   className="blog-screenshot"
@@ -101,7 +101,7 @@ a green checkmark, which means the whole run passed, so its builds are complete.
 
 For a pull request[^pr], open the PR and scroll down to its checks. Expand them,
 find a green check whose name starts with `Package / package`, and click it. The
-platform in the parentheses doesn't matter; they all belong to the same run, so
+platform in the parentheses doesn't matter. They all belong to the same run;
 any of them gets you there.
 
 <img
@@ -178,12 +178,12 @@ sudo unzip -o rancher-desktop-*-linux.zip -d /opt/rancher-desktop
 sudo chmod 04755 /opt/rancher-desktop/chrome-sandbox
 ```
 
-A manual extract leaves no desktop entry behind, so launch it directly with
+A manual extract leaves no desktop entry behind. Launch it directly with
 `/opt/rancher-desktop/rancher-desktop`[^linux-exe].
 
 On Rancher Desktop 2.0, the app refuses to start on a backend that a different
-`rdd` version created, so clear any existing one first (this removes your current
-2.0 workloads). The command is the same on every platform:
+`rdd` version created. You have to clear any existing one first (this removes
+your current 2.0 workloads). The command is the same on every platform:
 
 ```bash
 rdd svc delete
@@ -205,7 +205,7 @@ rdd svc delete        # Rancher Desktop 2.0
 Then install the release the normal way, from the project's releases page, or on
 Linux from our package repositories. On Rancher Desktop 1.x, restore the snapshot
 you took at the start, and your containers and cluster come back as they were. On
-2.0 there's no snapshot to restore, so you start fresh.
+2.0 there's no snapshot to restore; you start fresh.
 
 It's a lot of steps, though it does answer "is this actually fixed?" weeks ahead
 of the release.

--- a/blog/2026-07-16-installing-development-builds.md
+++ b/blog/2026-07-16-installing-development-builds.md
@@ -1,0 +1,227 @@
+---
+title: Running a Rancher Desktop Development Build
+slug: installing-development-builds
+authors: [jan]
+description: >-
+  You reported a bug against Rancher Desktop, someone fixed it, and the issue
+  got closed. But the fix is sitting on the main branch, and the next release
+  is still weeks out. You'd rather know now, while reopening the issue is still
+  easy. You can, because every merge to main, and every pull request, produces
+  an installable Rancher Desktop build, whether you're on 1.x or 2.0. Running
+  one is more involved than installing a release, and a bad build can damage
+  files on your host.
+---
+
+You reported a bug against Rancher Desktop, someone fixed it, and the issue got
+closed. But the fix is sitting on `main`, and the next release is still weeks
+out. You'd rather know now, while reopening the issue is still easy.
+You can, because every merge to `main`, and every pull request, produces an
+installable Rancher Desktop build, whether you're on 1.x or 2.0. Running one is
+more involved than installing a release, and a bad build can damage files on
+your host.
+
+<!-- truncate -->
+
+Sometimes the fix or feature you want hasn't been merged to `main`[^main] yet and
+lives only in an open pull request[^pr]. You can install that build too, and try
+the change before it lands.
+
+:::caution
+
+A development build hasn't been through the testing a release gets, so it can
+break in ways nothing has caught yet. A bad one can damage files on your host,
+outside the VM. Back up anything you can't afford to lose before you start.
+
+:::
+
+So this is really for people who are comfortable switching between versions and
+running factory resets, and who can put things back when a build breaks
+something. If that's not you, it's fine to wait for the release; the fix will
+land there soon enough.
+
+## The short version
+
+1. On 1.x, [take a snapshot](#have-a-way-back-before-you-start) first. 2.0 has
+   no equivalent, so its workloads are gone either way.
+2. [Find the build](#find-the-build) and download the artifact for your machine.
+3. [Unpack and install it](#unpack-and-install). On macOS, clear the quarantine
+   flag, or it refuses to open.
+4. On 2.0, clear the existing backend with `rdd svc delete` before you start.
+5. Check whether it fixes your problem, or try the feature you wanted.
+6. [Factory-reset](#going-back-to-a-release) from the development build.
+7. Install the release by hand, and on 1.x restore the snapshot from step 1.
+
+## Have a way back before you start
+
+There's no in-place downgrade back to a release. Going back takes a factory reset,
+and that reset wipes everything the backend is holding: your containers, images,
+volumes, and Kubernetes cluster.
+
+So on Rancher Desktop 1.x, take a snapshot before you install the development
+build. It captures all of that, and you can restore it once you're back on a
+release. Rancher Desktop 2.0 has no snapshot mechanism yet. It also refuses to
+start on a backend that a different `rdd`[^rdd] version created; switching
+versions there means clearing the backend and losing those workloads, in either
+direction. And even where you can snapshot, it only covers what's in the VM. A
+snapshot is not a backup of your host, and it won't save you from a build that
+damages files there.
+
+A development build also turns off auto-updates. It won't quietly replace itself,
+and it won't pull you back onto a release either. You reinstall the release build
+by hand when you're done.
+
+## Find the build
+
+:::note[Before you start]
+
+You need a GitHub account, and you have to be signed in before GitHub will let
+you download a build.
+
+Everything below happens in one of two repositories,
+[rancher-sandbox/rancher-desktop](https://github.com/rancher-sandbox/rancher-desktop)
+for 1.x or
+[rancher-sandbox/rancher-desktop-2](https://github.com/rancher-sandbox/rancher-desktop-2)
+for 2.0.
+
+:::
+
+Development builds come from GitHub Actions[^actions], from the workflow named
+**Package**.
+
+For the latest `main`, open the **Actions** tab, then filter to the **Package**
+workflow and the `main` branch. Or skip both dropdowns and type
+`branch:main workflow:Package` into the search box. Now pick the newest run with
+a green checkmark, which means the whole run passed, so its builds are complete.
+
+<img
+  className="blog-screenshot"
+  src="https://suse-rancher-media.s3.amazonaws.com/desktop/blog/2026/installing-development-builds/actions-package-main.png"
+  alt="The GitHub Actions tab, filtered to the Package workflow on the main branch, with the newest successful run at the top of the list."
+/>
+
+For a pull request[^pr], open the PR and scroll down to its checks. Expand them,
+find a green check whose name starts with `Package / package`, and click it. The
+platform in the parentheses doesn't matter; they all belong to the same run, so
+any of them gets you there.
+
+<img
+  className="blog-screenshot"
+  src="https://suse-rancher-media.s3.amazonaws.com/desktop/blog/2026/installing-development-builds/pr-checks-package.png"
+  alt="An open pull request with its checks expanded, showing a green Package / package check for each platform."
+/>
+
+Either way, you land on a workflow run. Click **Summary** in the left sidebar,
+then scroll to the bottom, where GitHub lists the artifacts. Each artifact is one
+operating system and CPU architecture. Find the one for your machine and click the
+download icon beside it. They're large, 600 MB and up.
+
+<img
+  className="blog-screenshot"
+  src="https://suse-rancher-media.s3.amazonaws.com/desktop/blog/2026/installing-development-builds/run-summary-artifacts.png"
+  alt="A workflow run Summary page with the Artifacts list, showing the installer, disk image, and zip downloads for each platform."
+/>
+
+On 2.0, the same run also produces an `RDD` artifact for each platform, which
+holds just the `rdd` binary with no app and no bundled tools. For a backend fix
+that's 50 to 60 MB against 600 and up, though GUI changes still need the full
+app. The binary still needs its quarantine flag cleared on macOS. The
+[installation post](/blog/installing-rancher-desktop-2) covers using `rdd` on its
+own.
+
+## Unpack and install
+
+What you downloaded is a ZIP, even on macOS and Windows, where a release hands
+you a `.dmg` or an installer directly. GitHub wraps every build artifact in a ZIP
+of its own. On every platform you unzip what you got first; the real artifact is
+inside.
+
+```console
+$ unzip "Rancher Desktop.aarch64.dmg.zip"
+Archive:  Rancher Desktop.aarch64.dmg.zip
+  inflating: Rancher Desktop-1.23.1-300-ge397ee701-arm64.dmg
+```
+
+The name changes on the way out[^arch]. That `1.23.1-300-ge397ee701` is
+`git describe` output, which pins down which build you ran[^msi]. Don't go
+hunting for that commit though. On a pull request GitHub builds a throwaway
+merge of the branch into its base, so it only exists for that run. Link the run
+itself when you report back.
+
+On **macOS**, that inner artifact is a `.dmg` (pick the one matching your chip,
+`aarch64` for Apple silicon or `x86_64` for Intel). Open it and drag the app into
+Applications, the same as a release. Because the build is unsigned, macOS marks it
+as quarantined and refuses to open it, so clear that flag once from a terminal.
+The 1.x app is `Rancher Desktop`; the 2.0 app is `Rancher Desktop 2`. Use the
+one you installed:
+
+```bash
+xattr -rd com.apple.quarantine "/Applications/Rancher Desktop.app"     # 1.x
+xattr -rd com.apple.quarantine "/Applications/Rancher Desktop 2.app"   # 2.0
+```
+
+On **Windows**, the inner artifact is an `.msi` installer. Run it. Windows will
+warn that it comes from an unknown publisher, again because the build is
+unsigned; approve it to continue.
+
+On **Linux**, the development build extracts to `/opt/rancher-desktop`, the same
+place our RPM and DEB packages install to. So if you have Rancher Desktop from one
+of those repositories, remove the package first; otherwise the two fight over
+that directory. If you extracted a development build there before, clear it out with
+`sudo rm -rf /opt/rancher-desktop`.
+
+The download itself holds a second ZIP with the application. Unpack that inner ZIP
+into place, then make the sandbox helper setuid so the app can launch:
+
+```bash
+unzip "Rancher Desktop-linux.zip"   # yields rancher-desktop-<version>-linux.zip
+sudo unzip -o rancher-desktop-*-linux.zip -d /opt/rancher-desktop
+sudo chmod 04755 /opt/rancher-desktop/chrome-sandbox
+```
+
+A manual extract leaves no desktop entry behind, so launch it directly with
+`/opt/rancher-desktop/rancher-desktop`[^linux-exe].
+
+On Rancher Desktop 2.0, the app refuses to start on a backend that a different
+`rdd` version created, so clear any existing one first (this removes your current
+2.0 workloads). The command is the same on every platform:
+
+```bash
+rdd svc delete
+```
+
+Then start Rancher Desktop the way you normally would; it runs like any release.
+
+## Going back to a release
+
+Once you're finished with the development build, clear its backend so a release
+can start clean. On Rancher Desktop 1.x that's `rdctl factory-reset`; on 2.0 it's
+`rdd svc delete`.
+
+```bash
+rdctl factory-reset   # Rancher Desktop 1.x
+rdd svc delete        # Rancher Desktop 2.0
+```
+
+Then install the release the normal way, from the project's releases page, or on
+Linux from our package repositories. On Rancher Desktop 1.x, restore the snapshot
+you took at the start, and your containers and cluster come back as they were. On
+2.0 there's no snapshot to restore, so you start fresh.
+
+It's a lot of steps, though it does answer "is this actually fixed?" weeks ahead
+of the release.
+
+[^main]: `main` is the primary line of development in the project's git repository on GitHub. A fix lands there once it is accepted, ahead of the next release.
+
+[^pr]: A pull request proposes a change and holds it for review until it is merged.
+
+[^rdd]: `rdd`, the Rancher Desktop Daemon, is the background program that runs the VM, the container engine, and the cluster in 2.0. [Welcome to Rancher Desktop 2.0](/blog/welcome-to-rancher-desktop-2).
+
+[^actions]: GitHub Actions is GitHub's build service. Each time a workflow runs it can leave files behind, called artifacts, which stay available for download.
+
+[^arch]: The artifact says `aarch64`, but the file inside says `arm64`. The `x86_64` build carries no architecture in its name at all.
+
+[^msi]: The 2.0 Windows installer is the exception, named `Rancher.Desktop.Setup.2.0.0.msi` with no build information in it. [Issue #572](https://github.com/rancher-sandbox/rancher-desktop-2/issues/572).
+
+[^linux-exe]: 2.0 uses the same path and executable name as 1.x, which is why the two collide on Linux. That may change in alpha 2. [Issue #509](https://github.com/rancher-sandbox/rancher-desktop-2/issues/509).
+
+<!-- TODO(jan): create the GitHub Discussion for this post and add the discussion: frontmatter + the bottom discussion link block, matching the other posts. -->

--- a/blog/2026-07-16-installing-development-builds.md
+++ b/blog/2026-07-16-installing-development-builds.md
@@ -41,15 +41,26 @@ soon enough.
 
 ## The short version
 
-1. On 1.x, [take a snapshot](#have-a-way-back-before-you-start) first. 2.0 has
-   no equivalent, so its workloads are gone either way.
+**On Rancher Desktop 1.x**
+
+1. [Take a snapshot](#have-a-way-back-before-you-start) first.
 2. [Find the build](#find-the-build) and download the artifact for your machine.
 3. [Unpack and install it](#unpack-and-install). On macOS, clear the quarantine
    flag, or it refuses to open.
-4. On 2.0, clear the existing backend with `rdd svc delete` before you start.
+4. Check whether it fixes your problem, or try the feature you wanted.
+5. [Factory-reset](#going-back-to-a-release) from the development build.
+6. Install the release by hand, then restore the snapshot from step 1.
+
+**On Rancher Desktop 2.0**
+
+1. There's no snapshot to take, so your existing workloads are gone either way.
+2. [Find the build](#find-the-build) and download the artifact for your machine.
+3. [Unpack and install it](#unpack-and-install). On macOS, clear the quarantine
+   flag, or it refuses to open.
+4. Clear the existing backend with `rdd svc delete` before you start.
 5. Check whether it fixes your problem, or try the feature you wanted.
-6. [Factory-reset](#going-back-to-a-release) from the development build.
-7. Install the release by hand, and on 1.x restore the snapshot from step 1.
+6. [Clear the backend again](#going-back-to-a-release) with `rdd svc delete`,
+   then install the release by hand.
 
 ## Have a way back before you start
 
@@ -99,7 +110,7 @@ a green checkmark, which means the whole run passed and its builds are complete.
   alt="The GitHub Actions tab, filtered to the Package workflow on the main branch, with the newest successful run at the top of the list."
 />
 
-For a pull request[^pr], open the PR and scroll down to its checks. Expand them,
+For a pull request, open the PR and scroll down to its checks. Expand them,
 find a green check whose name starts with `Package / package`, and click it. The
 platform in the parentheses doesn't matter. They all belong to the same run;
 any of them gets you there.
@@ -122,9 +133,10 @@ download icon beside it. They're large, 600 MB and up.
 />
 
 On 2.0, the same run also produces an `RDD` artifact for each platform, which
-holds just the `rdd` binary with no app and no bundled tools. For a backend fix
-that's 50 to 60 MB against 600 and up, though GUI changes still need the full
-app. The binary still needs its quarantine flag cleared on macOS. The
+holds just the `rdd` binary with no app and no bundled tools. For testing a
+backend fix you could use just this binary, as it's 50 to 60 MB (rather than
+600 plus), but GUI changes would still require downloading the full app. The
+binary still needs its quarantine flag cleared on macOS. The
 [installation post](/blog/installing-rancher-desktop-2) covers using `rdd` on its
 own.
 

--- a/blog/2026-07-21-installing-development-builds.md
+++ b/blog/2026-07-21-installing-development-builds.md
@@ -10,6 +10,7 @@ description: >-
   an installable Rancher Desktop build, whether you're on 1.x or 2.0. Running
   one is more involved than installing a release, and a bad build can damage
   files on your host.
+discussion: https://github.com/rancher-sandbox/rancher-desktop-2/discussions/575
 ---
 
 You reported a bug against Rancher Desktop, someone fixed it, and the issue got
@@ -236,4 +237,6 @@ of the release.
 
 [^linux-exe]: 2.0 uses the same path and executable name as 1.x, which is why the two collide on Linux. That may change in alpha 2. [Issue #509](https://github.com/rancher-sandbox/rancher-desktop-2/issues/509).
 
-<!-- TODO(jan): create the GitHub Discussion for this post and add the discussion: frontmatter + the bottom discussion link block, matching the other posts. -->
+---
+
+💬 Questions or feedback? **[Discuss this post on GitHub →](https://github.com/rancher-sandbox/rancher-desktop-2/discussions/575)**

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -75,6 +75,21 @@ html.blog-list-page article footer.docusaurus-mt-lg {
   margin-top: 0.75rem;
 }
 
+/* Blog screenshots. A light capture on a light page has no edge of its own, so
+   it gets a border, and the shadow lifts it off the text. Bottom margin only:
+   the gap above already comes from the preceding paragraph, and the shadow
+   bleeds downward, so the space below has to be larger to look even. Separate
+   from the older img_ rule above, which only matches Docusaurus-generated
+   markdown images; unifying the two across blog and docs is pending. */
+.blog-screenshot {
+  display: block;
+  max-width: 100%;
+  margin-bottom: calc(var(--ifm-leading) * 1.5);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2), 0 14px 36px rgba(0, 0, 0, 0.16);
+}
+
 /* Blog posts use a full-width three-column grid whose outer edges line up with
    the navbar: the table of contents and recent posts on the left, the article
    in a center column that grows with the window, and a reserved right column


### PR DESCRIPTION
The CI builds had no documented path for readers who want to verify a fix before it ships, or try a change that is still only in a pull request. The post covers finding a build, installing it on each platform, and getting back to a release.

The first commit adds a shared screenshot style, because a light screenshot on a light page has no edge of its own. It leaves the older `img_` docs rule alone; unifying the two is worth doing on its own.

Screenshots live on S3, so the checkout stays small.