### PR TITLE
Call it the defaulter in the Alpha 2 post

### DIFF
--- a/blog/2026-07-29-rancher-desktop-2-alpha-2.md
+++ b/blog/2026-07-29-rancher-desktop-2-alpha-2.md
@@ -94,8 +94,8 @@ rdd ctl patch app app --type merge --patch '{"spec":{"kubernetes":{"version":"st
 ```
 
 When you read the value back you can see that the alias has been replaced by
-the defaulting webhook[^webhook] with the actual version before it was
-stored in the object:
+the defaulter[^webhook] with the actual version before it was stored in the
+object:
 
 ```console
 $ rdd ctl get app app --output jsonpath='{.spec.kubernetes.version}'


### PR DESCRIPTION
The Alpha 2 post's body said "defaulting webhook" and its footnote then said it is a mutating admission webhook, which reads as two names for one thing, or worse, as two webhooks. The body now uses the plain name and the footnote supplies the Kubernetes term, which is what the margin note is there for.

Noticed just after #541 merged, so it needs its own branch.
